### PR TITLE
Fix DUB-based error highlighting

### DIFF
--- a/src/main/java/net/masterthought/dlanguage/highlighting/annotation/external/CompileCheck.java
+++ b/src/main/java/net/masterthought/dlanguage/highlighting/annotation/external/CompileCheck.java
@@ -66,7 +66,7 @@ public class CompileCheck {
 
 
     @NotNull
-    public Problems findProblems(String stdout, PsiFile file) {
+    private Problems findProblems(String stdout, PsiFile file) {
         final List<String> lints = StringUtil.split(stdout, "\n");
         Problems problems = new Problems();
         for (String lint : lints) {
@@ -111,13 +111,13 @@ public class CompileCheck {
         return line;
     }
 
-    public int getOffsetStart(final PsiFile file, int line, int column) {
+    private int getOffsetStart(final PsiFile file, int line, int column) {
         Document document = PsiDocumentManager.getInstance(file.getProject()).getDocument(file);
         line = getValidLineNumber(line, document);
         return getLineStartOffset(document, line) + column;
     }
 
-    public int getOffsetEnd(final PsiFile file, int line) {
+    private int getOffsetEnd(final PsiFile file, int line) {
         Document document = PsiDocumentManager.getInstance(file.getProject()).getDocument(file);
         line = getValidLineNumber(line, document);
         return getLineEndOffset(document, line);
@@ -130,7 +130,7 @@ public class CompileCheck {
     }
 
     @Nullable
-    public Problem parseProblem(String lint, PsiFile file) {
+    private Problem parseProblem(String lint, PsiFile file) {
         // Example DUB error:
         // src/hello.d(3,1): Error: only one main allowed
         Pattern p = Pattern.compile("([\\w\\\\/]+\\.d)\\((\\d+),(\\d+)\\):\\s(\\w+):(.+)");

--- a/src/main/java/net/masterthought/dlanguage/highlighting/annotation/external/CompileCheck.java
+++ b/src/main/java/net/masterthought/dlanguage/highlighting/annotation/external/CompileCheck.java
@@ -66,7 +66,7 @@ public class CompileCheck {
 
 
     @NotNull
-    public static Problems findProblems(String stdout, PsiFile file) {
+    public Problems findProblems(String stdout, PsiFile file) {
         final List<String> lints = StringUtil.split(stdout, "\n");
         Problems problems = new Problems();
         for (String lint : lints) {
@@ -75,7 +75,7 @@ public class CompileCheck {
         return problems;
     }
 
-    private static int getDocumentLineCount(Document document) {
+    private int getDocumentLineCount(Document document) {
         try {
             int lineCount = document.getLineCount();
             return lineCount == 0 ? 1 : lineCount;
@@ -84,7 +84,7 @@ public class CompileCheck {
         }
     }
 
-    private static int getLineStartOffset(Document document, int line) {
+    private int getLineStartOffset(Document document, int line) {
         try {
             return document.getLineStartOffset(line);
         } catch (Exception e) {
@@ -92,7 +92,7 @@ public class CompileCheck {
         }
     }
 
-    private static int getLineEndOffset(Document document, int line) {
+    private int getLineEndOffset(Document document, int line) {
         try {
             return document.getLineEndOffset(line);
         } catch (Exception e) {
@@ -100,7 +100,7 @@ public class CompileCheck {
         }
     }
 
-    private static int getValidLineNumber(int line, Document document) {
+    private int getValidLineNumber(int line, Document document) {
         int lineCount = getDocumentLineCount(document);
         line = line - 1;
         if (line <= 0) {
@@ -111,26 +111,26 @@ public class CompileCheck {
         return line;
     }
 
-    public static int getOffsetStart(final PsiFile file, int line, int column) {
+    public int getOffsetStart(final PsiFile file, int line, int column) {
         Document document = PsiDocumentManager.getInstance(file.getProject()).getDocument(file);
         line = getValidLineNumber(line, document);
         return getLineStartOffset(document, line) + column;
     }
 
-    public static int getOffsetEnd(final PsiFile file, int line) {
+    public int getOffsetEnd(final PsiFile file, int line) {
         Document document = PsiDocumentManager.getInstance(file.getProject()).getDocument(file);
         line = getValidLineNumber(line, document);
         return getLineEndOffset(document, line);
     }
 
-    private static TextRange calculateTextRange(PsiFile file, int line, int column) {
+    private TextRange calculateTextRange(PsiFile file, int line, int column) {
         final int startOffset = getOffsetStart(file, line, column);
         final int endOffset = getOffsetEnd(file, line);
         return new TextRange(startOffset, endOffset);
     }
 
     @Nullable
-    public static Problem parseProblem(String lint, PsiFile file) {
+    public Problem parseProblem(String lint, PsiFile file) {
         // Example DUB error:
         // src/hello.d(3,1): Error: only one main allowed
         Pattern p = Pattern.compile("([\\w\\\\/]+\\.d)\\((\\d+),(\\d+)\\):\\s(\\w+):(.+)");
@@ -158,7 +158,7 @@ public class CompileCheck {
         }
     }
 
-    private static boolean isSameFile(PsiFile file, String relativeOtherFilePath) {
+    private boolean isSameFile(PsiFile file, String relativeOtherFilePath) {
         String filePath = file.getVirtualFile().getPath();
         String unixRelativeOtherFilePath = relativeOtherFilePath.replace('\\', '/');
         return filePath.endsWith(unixRelativeOtherFilePath);

--- a/src/main/java/net/masterthought/dlanguage/highlighting/annotation/external/CompileCheck.java
+++ b/src/main/java/net/masterthought/dlanguage/highlighting/annotation/external/CompileCheck.java
@@ -28,7 +28,7 @@ public class CompileCheck {
 
     public Problems checkFileSyntax(@NotNull PsiFile file) {
         final String dubPath = ToolKey.DUB_KEY.getPath(file.getProject());
-               if (dubPath == null) return new Problems();
+        if (dubPath == null) return new Problems();
 
         String result = processFile(file, dubPath);
         return findProblems(result, file);
@@ -100,7 +100,7 @@ public class CompileCheck {
         }
     }
 
-    private static int getValidLineNumber(int line, Document document){
+    private static int getValidLineNumber(int line, Document document) {
         int lineCount = getDocumentLineCount(document);
         line = line - 1;
         if (line <= 0) {
@@ -132,7 +132,7 @@ public class CompileCheck {
     // hello.d(3): Error: only one main allowed
     @Nullable
     public static Problem parseProblem(String lint, PsiFile file) {
-        Pattern p = Pattern.compile("(\\w+\\.d)\\((\\d+)\\):\\s(\\w+):(.+)");
+        Pattern p = Pattern.compile("([\\w\\\\/]+\\.d)\\((\\d+),(\\d+)\\):\\s(\\w+):(.+)");
         Matcher m = p.matcher(lint);
 
         String sourceFile = "";
@@ -143,9 +143,10 @@ public class CompileCheck {
         while (m.find()) {
             sourceFile = m.group(1);
             line = Integer.valueOf(m.group(2));
-            severity = m.group(3);
-            message = m.group(4);
+            severity = m.group(4);
+            message = m.group(5);
         }
+
         if (sourceFile.equals(file.getName())) {
             TextRange range = calculateTextRange(file, line);
             return new Problem(range, message, severity);

--- a/src/main/java/net/masterthought/dlanguage/highlighting/annotation/external/CompileCheck.java
+++ b/src/main/java/net/masterthought/dlanguage/highlighting/annotation/external/CompileCheck.java
@@ -141,8 +141,10 @@ public class CompileCheck {
         int line = 0;
         int column = 0;
         String severity = "";
+        boolean hasMatch = false;
 
         while (m.find()) {
+            hasMatch = true;
             sourceFile = m.group(1);
             line = Integer.valueOf(m.group(2));
             column = Integer.valueOf(m.group(3)) - 1;
@@ -150,7 +152,7 @@ public class CompileCheck {
             message = m.group(5);
         }
 
-        if (isSameFile(file, sourceFile)) {
+        if (hasMatch && isSameFile(file, sourceFile)) {
             TextRange range = calculateTextRange(file, line, column);
             return new Problem(range, message, severity);
         } else {

--- a/src/main/java/net/masterthought/dlanguage/highlighting/annotation/external/CompileCheck.java
+++ b/src/main/java/net/masterthought/dlanguage/highlighting/annotation/external/CompileCheck.java
@@ -129,9 +129,10 @@ public class CompileCheck {
         return new TextRange(startOffset, endOffset);
     }
 
-    // hello.d(3): Error: only one main allowed
     @Nullable
     public static Problem parseProblem(String lint, PsiFile file) {
+        // Example DUB error:
+        // src/hello.d(3, 1): Error: only one main allowed
         Pattern p = Pattern.compile("([\\w\\\\/]+\\.d)\\((\\d+),(\\d+)\\):\\s(\\w+):(.+)");
         Matcher m = p.matcher(lint);
 
@@ -147,12 +148,18 @@ public class CompileCheck {
             message = m.group(5);
         }
 
-        if (sourceFile.equals(file.getName())) {
+        if (isSameFile(file, sourceFile)) {
             TextRange range = calculateTextRange(file, line);
             return new Problem(range, message, severity);
         } else {
             return null;
         }
+    }
+
+    private static boolean isSameFile(PsiFile file, String relativeOtherFilePath) {
+        String filePath = file.getVirtualFile().getPath();
+        String unixRelativeOtherFilePath = relativeOtherFilePath.replace('\\', '/');
+        return filePath.endsWith(unixRelativeOtherFilePath);
     }
 
     public static class Problem extends DProblem {


### PR DESCRIPTION
Several problems prevented the CompileCheck from properly parsing and reporting DUB errors:

- The regex did not take into account the column number specifier
- The regex did not take sourcefiles in sub-directories into account
- The check whether the error applied to the current source file did not take sub-directories into account
- DUB messages which weren't problem reports also got added to the problem output

This pull fixes these issues and cleans up the CompileCheck class somewhat