### PR TITLE
#57 further CLion support: opening existing projects, auto detect dmd compiler, APIs cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,8 @@ allprojects {
         pluginName 'intellij-dlanguage'
         version ideaVersion
         updateSinceUntilBuild false
+        // uncomment to test/run/debug the plugin with CLion
+        //alternativeIdePath '<path to>/CLion.app'
 
         publishPlugin {
             username System.getenv('SB_JETBRAINS_USERNAME')

--- a/src/main/java/io/github/intellij/dlanguage/DlangSdkType.java
+++ b/src/main/java/io/github/intellij/dlanguage/DlangSdkType.java
@@ -71,8 +71,9 @@ public class DlangSdkType extends SdkType {
         } else if (SystemInfo.isMac) {
             DEFAULT_DMD_PATHS = new File[] {
                 new File("/usr/local/opt/dmd"),
-                new File("/usr/local/bin")
-            };
+                new File("/usr/local/bin"),
+                new File("/opt/local/bin")
+                };
             DEFAULT_DOCUMENTATION_PATHS = new File[]{};
             DEFAULT_PHOBOS_PATHS = new File[] {
                 new File("/Library/D/dmd/src/phobos")
@@ -135,12 +136,18 @@ public class DlangSdkType extends SdkType {
     @Nullable
     @Override
     public String suggestHomePath() {
-        for (File f : DEFAULT_DMD_PATHS) {
+        File found = null;
+        for (final File f : DEFAULT_DMD_PATHS) {
             if (f.exists()) {
-                return f.getAbsolutePath();
-            }
+                if (isValidSdkHome(f.getPath())) {
+                  found = f;
+                  break;
+                } else if (found == null) {
+                  found = f;
+                }
+            } 
         }
-        return null;
+        return found == null ? null : found.getAbsolutePath();
     }
 
     /* When user set up DMD SDK path this method checks if specified path contains DMD compiler executable. */

--- a/src/main/java/io/github/intellij/dlanguage/DlangSdkType.java
+++ b/src/main/java/io/github/intellij/dlanguage/DlangSdkType.java
@@ -9,6 +9,7 @@ import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.projectRoots.*;
+import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
@@ -27,6 +28,7 @@ import javax.swing.*;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -463,6 +465,21 @@ public class DlangSdkType extends SdkType {
 //        final File dmdCompilerFile = new File(sdkHome, executableName);
 //        return dmdCompilerFile.getAbsolutePath();
 //    }
+
+    public static Sdk findOrCreateSdk() {
+        final DlangSdkType sdkType = DlangSdkType.getInstance();
+
+        final Comparator<Sdk> sdkComparator = (sdk1, sdk2) -> {
+            if (sdk1.getSdkType() == sdkType) {
+                return -1;
+            } else if (sdk2.getSdkType() == sdkType) {
+                return 1;
+            } else {
+                return 0;
+            }
+        };
+        return SdkConfigurationUtil.findOrCreateSdk(sdkComparator, sdkType);
+    }
 }
 
 

--- a/src/main/java/io/github/intellij/dlanguage/module/DlangDubModuleBuilder.java
+++ b/src/main/java/io/github/intellij/dlanguage/module/DlangDubModuleBuilder.java
@@ -89,6 +89,13 @@ public class DlangDubModuleBuilder extends DlangModuleBuilder {
         return sourcePaths;
     }
 
+    public void addSourcePath(final Pair<String, String> sourcePathInfo) {
+        if (sourcePaths == null) {
+            sourcePaths = new ArrayList<>();
+        }
+        sourcePaths.add(sourcePathInfo);
+    }
+
     public void setDubOptions(final Map<String, String> options) {
         this.dubOptions = options;
     }

--- a/src/main/java/io/github/intellij/dlanguage/project/CLionDubProjectOpenProcessor.java
+++ b/src/main/java/io/github/intellij/dlanguage/project/CLionDubProjectOpenProcessor.java
@@ -1,0 +1,91 @@
+package io.github.intellij.dlanguage.project;
+
+import com.intellij.ide.GeneralSettings;
+import com.intellij.ide.impl.ProjectUtil;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ex.ProjectManagerEx;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.projectImport.ProjectOpenProcessor;
+import com.intellij.util.ArrayUtil;
+import io.github.intellij.dlanguage.DlangSdkType;
+import io.github.intellij.dlanguage.icons.DlangIcons;
+import io.github.intellij.dlanguage.module.DlangModuleBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.Icon;
+
+/**
+ * Used when opening a dub project within a non-Java IDE
+ */
+public class CLionDubProjectOpenProcessor extends ProjectOpenProcessor {
+  static final String NAME = "Dub";
+  static final String[] SUPPORTED_FILES = {"dub.json", "dub.sdl"};
+
+  @Nullable
+  @Override
+  public Icon getIcon() {
+    return DlangIcons.FILE;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public boolean canOpenProject(final VirtualFile file) {
+    return findSupportedFile(file) != null;
+  }
+
+  @Nullable
+  private VirtualFile findSupportedFile(final VirtualFile file) {
+    if (file.isDirectory()) {
+      final VirtualFile[] children = file.getChildren();
+      if (children != null) {
+        for (final VirtualFile child : children) {
+          if (ArrayUtil.contains(child.getName(), SUPPORTED_FILES)) return child;
+        }
+      }
+      return null;
+    } else {
+      return ArrayUtil.contains(file.getName(), SUPPORTED_FILES) ? file : null;
+    }
+  }
+
+  @Nullable
+  @Override
+  public Project doOpenProject(@NotNull final VirtualFile virtualFile,
+                               @Nullable final Project projectToClose,
+                               final boolean forceOpenInNewFrame) {
+    if (projectToClose != null && !forceOpenInNewFrame) {
+      final int exitCode = ProjectUtil.confirmOpenNewProject(false);
+      if (exitCode == GeneralSettings.OPEN_PROJECT_SAME_WINDOW) {
+        if (!ProjectUtil.closeAndDispose(projectToClose)) {
+          return null;
+        }
+      } else if (exitCode != GeneralSettings.OPEN_PROJECT_NEW_WINDOW) {
+        // not in a new window
+        return null;
+      }
+    }
+
+    final VirtualFile baseDir = virtualFile.isDirectory() ? virtualFile : virtualFile.getParent();
+    final Project project = ProjectManagerEx.getInstanceEx()
+        .newProject(baseDir.getName(), baseDir.getPath(), true, false);
+    if (project != null) {
+      WriteAction.run(() -> {
+        final Sdk sdk = DlangSdkType.findOrCreateSdk();
+        ProjectRootManager.getInstance(project).setProjectSdk(sdk);
+        final DlangModuleBuilder builder = new DlangModuleBuilder();
+        builder.setModuleJdk(sdk);
+        builder.commit(project);
+      });
+      ProjectManagerEx.getInstanceEx().openProject(project);
+    }
+    return project;
+  }
+}

--- a/src/main/java/io/github/intellij/dlanguage/project/DubProjectImportBuilder.java
+++ b/src/main/java/io/github/intellij/dlanguage/project/DubProjectImportBuilder.java
@@ -11,8 +11,6 @@ import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.module.ModuleWithNameAlreadyExists;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
 import com.intellij.openapi.util.InvalidDataException;
@@ -21,9 +19,9 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.packaging.artifacts.ModifiableArtifactModel;
 import com.intellij.projectImport.ProjectImportBuilder;
-import io.github.intellij.dlanguage.module.DlangDubModuleBuilder;
 import io.github.intellij.dlanguage.DlangSdkType;
 import io.github.intellij.dlanguage.icons.DlangIcons;
+import io.github.intellij.dlanguage.module.DlangDubModuleBuilder;
 import io.github.intellij.dlanguage.utils.DToolsNotificationListener;
 import org.jdom.JDOMException;
 import org.jetbrains.annotations.NotNull;
@@ -32,7 +30,6 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -57,7 +54,7 @@ public class DubProjectImportBuilder extends ProjectImportBuilder<DubPackage> {
     @NotNull
     @Override
     public String getName() {
-        return "Dub";
+        return CLionDubProjectOpenProcessor.NAME;
     }
 
     @Override
@@ -160,22 +157,7 @@ public class DubProjectImportBuilder extends ProjectImportBuilder<DubPackage> {
     }
 
     private void commitSdk(final Project project) {
-        ProjectRootManager.getInstance(project).setProjectSdk(findOrCreateSdk());
-    }
-
-    private Sdk findOrCreateSdk() {
-        final DlangSdkType sdkType = DlangSdkType.getInstance();
-
-        final Comparator<Sdk> sdkComparator = (sdk1, sdk2) -> {
-            if (sdk1.getSdkType() == sdkType) {
-                return -1;
-            } else if (sdk2.getSdkType() == sdkType) {
-                return 1;
-            } else {
-                return 0;
-            }
-        };
-        return SdkConfigurationUtil.findOrCreateSdk(sdkComparator, sdkType);
+        ProjectRootManager.getInstance(project).setProjectSdk(DlangSdkType.findOrCreateSdk());
     }
 
     public static class Parameters {

--- a/src/main/java/io/github/intellij/dlanguage/project/DubProjectOpenProcessor.java
+++ b/src/main/java/io/github/intellij/dlanguage/project/DubProjectOpenProcessor.java
@@ -18,7 +18,6 @@ import javax.swing.*;
  * Used when opening a dub project within the IDE
  */
 public class DubProjectOpenProcessor extends ProjectOpenProcessorBase<DubProjectImportBuilder> {
-
     private static final Logger LOG = Logger.getInstance(DubProjectOpenProcessor.class.getName());
 
     public DubProjectOpenProcessor(@NotNull final DubProjectImportBuilder builder) {
@@ -27,7 +26,7 @@ public class DubProjectOpenProcessor extends ProjectOpenProcessorBase<DubProject
 
     @Nullable
     public String[] getSupportedExtensions() {
-        return new String[] {"dub.json","dub.sdl"};
+        return CLionDubProjectOpenProcessor.SUPPORTED_FILES;
     }
 
     @Nullable

--- a/src/main/java/io/github/intellij/dlanguage/utils/GuiUtil.java
+++ b/src/main/java/io/github/intellij/dlanguage/utils/GuiUtil.java
@@ -1,11 +1,13 @@
 package io.github.intellij.dlanguage.utils;
 
-import com.intellij.openapi.externalSystem.util.ExternalSystemUiUtil;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.ui.TextAccessor;
 import com.intellij.ui.TextFieldWithHistory;
+import com.intellij.util.ui.GridBag;
+import com.intellij.util.ui.JBUI;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
@@ -32,14 +34,14 @@ public class GuiUtil {
         // Add elements to Panel.
         final JPanel subPanel = new JPanel(new GridBagLayout());
         subPanel.add(new JLabel(tool + " executable path:"));
-        subPanel.add(tf, ExternalSystemUiUtil.getFillLineConstraints(0));
+        subPanel.add(tf, getFillLineConstraints());
         settings.add(subPanel, constraints);
 
         return tf;
     }
 
     public static TextFieldWithBrowseButton createExecutableOption(final JPanel settings, final String tool) {
-        return createExecutableOption(settings, tool, ExternalSystemUiUtil.getFillLineConstraints(0));
+        return createExecutableOption(settings, tool, getFillLineConstraints());
     }
 
     /**
@@ -57,14 +59,14 @@ public class GuiUtil {
         // Add elements to Panel.
         final JPanel subPanel = new JPanel(new GridBagLayout());
         subPanel.add(new JLabel(labelText + ':'));
-        subPanel.add(tf, ExternalSystemUiUtil.getFillLineConstraints(0));
+        subPanel.add(tf, getFillLineConstraints());
         settings.add(subPanel, constraints);
 
         return tf;
     }
 
     public static TextFieldWithHistory createTextfield(final JPanel settings, final String labelText) {
-        return createTextfield(settings, labelText, ExternalSystemUiUtil.getFillLineConstraints(0));
+        return createTextfield(settings, labelText, getFillLineConstraints());
     }
 
     /**
@@ -80,14 +82,14 @@ public class GuiUtil {
         // Add elements to Panel.
         final JPanel subPanel = new JPanel(new GridBagLayout());
         subPanel.add(new JLabel(tool + " version:"));
-        subPanel.add(tf, ExternalSystemUiUtil.getFillLineConstraints(0));
+        subPanel.add(tf, getFillLineConstraints());
         settings.add(subPanel, constraints);
 
         return tf;
     }
 
     public static JLabel createDisplayVersion(final JPanel settings, final String tool) {
-        return createDisplayVersion(settings, tool, ExternalSystemUiUtil.getFillLineConstraints(0));
+        return createDisplayVersion(settings, tool, getFillLineConstraints());
     }
 
     /**
@@ -105,7 +107,7 @@ public class GuiUtil {
     }
 
     public static JCheckBox createCheckBoxOption(final JPanel settings, final String text) {
-        return createCheckBoxOption(settings, text, ExternalSystemUiUtil.getFillLineConstraints(0));
+        return createCheckBoxOption(settings, text, getFillLineConstraints());
     }
 
     public static void addFolderListener(final TextFieldWithBrowseButton textField, final String executable) {
@@ -128,4 +130,14 @@ public class GuiUtil {
         button.addActionListener(createApplyPathAction(textField, executable));
     }
 
+    @NotNull
+    private static GridBag getFillLineConstraints() {
+        final int INSETS = 5;
+        return new GridBag().weightx(1)
+            .coverLine()
+            .fillCellHorizontally()
+            .anchor(GridBagConstraints.WEST)
+            .insets(JBUI.insets(INSETS, INSETS + INSETS, 0, INSETS));
+    }
+    
 }

--- a/src/main/kotlin/io/github/intellij/dlanguage/project/creation.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/project/creation.kt
@@ -6,6 +6,8 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil
+import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.impl.welcomeScreen.AbstractActionWithPanel
@@ -16,6 +18,7 @@ import com.intellij.platform.ProjectGeneratorPeer
 import com.intellij.ui.components.JBPanel
 import com.intellij.util.PlatformUtils
 import com.intellij.util.ui.components.BorderLayoutPanel
+import io.github.intellij.dlanguage.DlangSdkType
 import io.github.intellij.dlanguage.icons.DlangIcons
 import io.github.intellij.dlanguage.project.ui.DmdCompilerComboBox
 import io.github.intellij.dlanguage.project.ui.DubInitCheckBox
@@ -74,22 +77,7 @@ class DlangProjectGenerator : DirectoryProjectGeneratorBase<Any>(), CustomStepPr
     }
 
     override fun generateProject(project: Project, baseDir: VirtualFile, settings: Any, module: Module) {
-//        val sdkType = DlangSdkType.getInstance()
-//
-//        val sdkComparator: Comparator<Sdk> = Comparator({ sdk1: Sdk, sdk2: Sdk ->
-//            when (sdkType) {
-//                sdk1.sdkType -> -1
-//                sdk2.sdkType -> 1
-//                else -> 0
-//            }
-//        })
-
-        //SdkConfigurationUtil.configureDirectoryProjectSdk(project, sdkComparator, sdkType)
-//        val dmd: Sdk? = SdkConfigurationUtil.findOrCreateSdk(sdkComparator, sdkType)
-//
-//        ApplicationManager.getApplication().run {
-//            ProjectRootManager.getInstance(project).projectSdk = dmd
-//        }
+        SdkConfigurationUtil.setDirectoryProjectSdk(project, DlangSdkType.findOrCreateSdk())
 
         val platformPrefix = PlatformUtils.getPlatformPrefix()
         when(platformPrefix) {
@@ -100,18 +88,7 @@ class DlangProjectGenerator : DirectoryProjectGeneratorBase<Any>(), CustomStepPr
                 // create a cmake file. The LDC project has a good example of using cmake with D:
                 // https://github.com/ldc-developers/ldc
                 ApplicationManager.getApplication().runWriteAction {
-                    baseDir.createChildDirectory(this, "src")
-                    baseDir.createChildData(this, "src/app.d")
-                    val cmakeList = baseDir.createChildData(this, "CMakeLists.txt")
-                    VfsUtil.saveText(cmakeList, """
-                        |cmake_minimum_required(VERSION 2.8)
-                        |
-                        |project(${project.name})
-                        |
-                        |file(GLOB SOURCES "src/*.d")
-                        |
-                        |add_executable(${project.name} ${"$"}{SOURCES})""".trimMargin()
-                    )
+                    baseDir.createChildDirectory(this, "src").createChildData(this, "app.d")
                 }
             }
             PlatformUtils.RIDER_PREFIX-> log.info("we have Rider")

--- a/src/main/resources/META-INF/clion-only.xml
+++ b/src/main/resources/META-INF/clion-only.xml
@@ -4,6 +4,9 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <directoryProjectGenerator implementation="io.github.intellij.dlanguage.project.DlangProjectGenerator"/>
+
+        <projectOpenProcessor id="DubProjectOpenProcessor"
+                              implementation="io.github.intellij.dlanguage.project.CLionDubProjectOpenProcessor" order="first"/>
     </extensions>
 
 </idea-plugin>

--- a/src/main/resources/META-INF/idea-only.xml
+++ b/src/main/resources/META-INF/idea-only.xml
@@ -9,6 +9,9 @@
         <moduleBuilder id="DLangDubModuleBuilder"
                        builderClass="io.github.intellij.dlanguage.module.DlangDubModuleBuilder"/>
 
+        <projectImportProvider implementation="io.github.intellij.dlanguage.project.DubProjectImportProvider"/>
+        <projectImportBuilder implementation="io.github.intellij.dlanguage.project.DubProjectImportBuilder"/>
+        <projectOpenProcessor id="DubProjectOpenProcessor" implementation="io.github.intellij.dlanguage.project.DubProjectOpenProcessor"/>
     </extensions>
 
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -84,11 +84,6 @@
         <projectSdkSetupValidator implementation="io.github.intellij.dlanguage.DLangProjectDmdSetupValidator" />
         <runConfigurationProducer implementation="io.github.intellij.dlanguage.run.DlangRunDubConfigurationProducer"/>
 
-        <!-- project open and import -->
-        <projectImportProvider implementation="io.github.intellij.dlanguage.project.DubProjectImportProvider"/>
-        <projectImportBuilder implementation="io.github.intellij.dlanguage.project.DubProjectImportBuilder"/>
-        <projectOpenProcessor id="DubProjectOpenProcessor" implementation="io.github.intellij.dlanguage.project.DubProjectOpenProcessor"/>
-
         <!-- module -->
         <internalFileTemplate name="D Language Module"/>
         <moduleType id="DLANGUAGE_MODULE" implementationClass="io.github.intellij.dlanguage.module.DlangModuleType"/>


### PR DESCRIPTION
* basic ProjectOpenProcessor to open dub-based projects in CLion
* extract IDEA-only plugin dependencies
* replace usages of IDEA-only APIs with generic APIs
* auto-detect dmd compiler from MacPorts

More details are provided in the inline comments