### PR TITLE
Enable MagoMI / GDB on Windows Subsystem for linux 

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/project/DubConfigurationParser.java
+++ b/src/main/java/io/github/intellij/dlanguage/project/DubConfigurationParser.java
@@ -87,7 +87,8 @@ public class DubConfigurationParser {
      * @return true if a path to a dub binary is configured and the project has a dub.sdl or dub.json
      */
     public boolean canUseDub() {
-        final boolean dubPathValid = StringUtil.isNotEmpty(this.dubBinaryPath) && (dubBinaryPath.endsWith("dub") || dubBinaryPath.endsWith("dub.exe"));
+        // For wsl, dub command can have any file name not only dub/dub.exe
+        final boolean dubPathValid = StringUtil.isNotEmpty(this.dubBinaryPath);
 
         final VirtualFile baseDir = project.getBaseDir();
         baseDir.refresh(true, true);

--- a/src/main/java/io/github/intellij/dlanguage/run/RunUtil.java
+++ b/src/main/java/io/github/intellij/dlanguage/run/RunUtil.java
@@ -49,16 +49,13 @@ public class RunUtil {
             return null;
         }
 
-        if (SdkUtil.isHostOsWindows()) {
-            execName = execName.concat(".exe");
-        }
-
+        final String executableFilePath = execName;
         final XDebugSession debugSession = XDebuggerManager.getInstance(project).startSession(env,
             new XDebugProcessStarter() {
                 @NotNull
                 @Override
                 public XDebugProcess start(@NotNull XDebugSession session) throws ExecutionException {
-                    return new GdbDebugProcess(project, session, result);
+                    return new GdbDebugProcess(project, session, result, executableFilePath);
                 }
             });
 
@@ -74,8 +71,6 @@ public class RunUtil {
             }
         });
 
-        gdbProcess.sendCommand("file " + execName);
-
         // Send startup commands
         String[] commandsArray = new String[0];//configuration.STARTUP_COMMANDS.split("\\r?\\n");
         for (String command : commandsArray) {
@@ -86,7 +81,7 @@ public class RunUtil {
         }
 
 //        if (configuration.autoStartGdb) {
-        gdbProcess.sendCommand("run");
+        gdbProcess.sendCommand("-exec-run");
 //        }
 
         return debugSession.getRunContentDescriptor();

--- a/src/main/java/uk/co/cwspencer/gdb/Gdb.java
+++ b/src/main/java/uk/co/cwspencer/gdb/Gdb.java
@@ -282,7 +282,9 @@ public class Gdb {
 
 //            String[] goEnv = SdkUtil.getExtendedGoEnv(sdkData, projectDir, "");
 
-            Process process = Runtime.getRuntime().exec(commandLine, new String[]{}, workingDirectoryFile);
+            final ProcessBuilder pb = new ProcessBuilder(commandLine);
+            pb.directory(workingDirectoryFile);
+            final Process process = pb.start();
             InputStream stream = process.getInputStream();
 
             // Save a reference to the process and launch the writer thread

--- a/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbDebugProcess.java
+++ b/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbDebugProcess.java
@@ -55,6 +55,7 @@ import uk.co.cwspencer.gdb.gdbmi.GdbMiStreamRecord;
 import uk.co.cwspencer.gdb.messages.*;
 import uk.co.cwspencer.ideagdb.debug.breakpoints.GdbBreakpointHandler;
 import uk.co.cwspencer.ideagdb.debug.breakpoints.GdbBreakpointProperties;
+import uk.co.cwspencer.ideagdb.debug.utils.SdkUtil;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -83,13 +84,13 @@ public class GdbDebugProcess extends XDebugProcess implements GdbListener {
     /**
      * Constructor; launches GDB.
      */
-    public GdbDebugProcess(Project project, XDebugSession session, ExecutionResult result) {
+    public GdbDebugProcess(Project project, XDebugSession session, ExecutionResult result, String execName) {
         super(session);
         m_console = (ConsoleView) result.getExecutionConsole();
-        init(session);
+        init(session, execName);
     }
 
-    private void init(XDebugSession session) {
+    private void init(XDebugSession session, String execName) {
         Project project = session.getProject();
         m_project = project;
         debugSession = session;
@@ -104,8 +105,12 @@ public class GdbDebugProcess extends XDebugProcess implements GdbListener {
         m_gdbConsole.getConsole().print(m_timeFormat.format(new Date()) + " 0> " +
             ToolKey.GDB_KEY.getPath() + " --interpreter=mi2\n", ConsoleViewContentType.USER_INPUT);
 
+        m_gdb.sendCommand("-file-exec-and-symbols " + execName);
+
+        boolean isWsl = SdkUtil.isWslPath(execName);
+
         // Create the breakpoint handler
-        m_breakpointHandler = new GdbBreakpointHandler(m_gdb, this);
+        m_breakpointHandler = new GdbBreakpointHandler(m_gdb, this, isWsl);
 
         // Launch the process
         m_gdb.start();

--- a/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbExecutionStack.java
+++ b/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbExecutionStack.java
@@ -120,6 +120,7 @@ public class GdbExecutionStack extends XExecutionStack {
         if (stackTrace.stack == null || stackTrace.stack.isEmpty()) {
             // No data
             container.addStackFrames(new ArrayList<XStackFrame>(0), true);
+            return;
         }
 
         // Build a list of GdbExecutionStaceFrames

--- a/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbExecutionStackFrame.java
+++ b/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbExecutionStackFrame.java
@@ -28,6 +28,7 @@ import com.intellij.icons.AllIcons;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.ColoredTextContainer;
 import com.intellij.ui.SimpleColoredComponent;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.xdebugger.XDebuggerBundle;
@@ -41,6 +42,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import uk.co.cwspencer.gdb.Gdb;
 import uk.co.cwspencer.gdb.messages.*;
+import uk.co.cwspencer.ideagdb.debug.utils.SdkUtil;
 
 import java.io.File;
 
@@ -120,6 +122,11 @@ public class GdbExecutionStackFrame extends XStackFrame {
         }
 
         String path = m_frame.fileAbsolute.replace(File.separatorChar, '/');
+
+        if (SdkUtil.isWslPath(path)) {
+            path = SdkUtil.translateWslPosixToWindowsPath(path);
+        }
+
         VirtualFile file = LocalFileSystem.getInstance().findFileByPath(path);
         if (file == null) {
             return null;
@@ -133,7 +140,7 @@ public class GdbExecutionStackFrame extends XStackFrame {
      *
      * @param component The stack frame visual component.
      */
-    public void customizePresentation(SimpleColoredComponent component) {
+    public void customizePresentation(@NotNull ColoredTextContainer component) {
         if (m_frame.address == null) {
             component.append(XDebuggerBundle.message("invalid.frame"),
                 SimpleTextAttributes.ERROR_ATTRIBUTES);
@@ -172,7 +179,7 @@ public class GdbExecutionStackFrame extends XStackFrame {
         } else {
             String addressStr = "0x" + Long.toHexString(m_frame.address);
             component.append(addressStr, SimpleTextAttributes.GRAY_ITALIC_ATTRIBUTES);
-            component.appendTextPadding(addressStr.length());
+            //component.appendTextPadding(addressStr.length());
         }
         component.setIcon(AllIcons.Debugger.StackFrame);
     }

--- a/src/main/java/uk/co/cwspencer/ideagdb/debug/breakpoints/GdbBreakpointHandler.java
+++ b/src/main/java/uk/co/cwspencer/ideagdb/debug/breakpoints/GdbBreakpointHandler.java
@@ -36,6 +36,7 @@ import uk.co.cwspencer.gdb.messages.GdbBreakpoint;
 import uk.co.cwspencer.gdb.messages.GdbErrorEvent;
 import uk.co.cwspencer.gdb.messages.GdbEvent;
 import uk.co.cwspencer.ideagdb.debug.GdbDebugProcess;
+import uk.co.cwspencer.ideagdb.debug.utils.SdkUtil;
 
 import java.util.List;
 
@@ -48,11 +49,13 @@ public class GdbBreakpointHandler extends
         m_breakpoints = new BidirectionalMap<Integer, XLineBreakpoint<GdbBreakpointProperties>>();
     private final Gdb m_gdb;
     private final GdbDebugProcess m_debugProcess;
+    private final boolean m_isWsl;
 
-    public GdbBreakpointHandler(Gdb gdb, GdbDebugProcess debugProcess) {
+    public GdbBreakpointHandler(Gdb gdb, GdbDebugProcess debugProcess, boolean isWsl) {
         super(GdbBreakpointType.class);
         m_gdb = gdb;
         m_debugProcess = debugProcess;
+        m_isWsl = isWsl;
     }
 
     /**
@@ -77,7 +80,12 @@ public class GdbBreakpointHandler extends
                 return;
             }
 
-            String command = "-break-insert -f " + sourcePosition.getFile().getPath() + ":" + (sourcePosition.getLine() + 1);
+            String filePath = sourcePosition.getFile().getPath();
+            if (m_isWsl) {
+                filePath = SdkUtil.translateWslWindowsToPosixPath(filePath);
+            }
+
+            String command = "-break-insert -f " + filePath + ":" + (sourcePosition.getLine() + 1);
             m_gdb.sendCommand(command, new Gdb.GdbEventCallback() {
                 @Override
                 public void onGdbCommandCompleted(GdbEvent event) {

--- a/src/main/java/uk/co/cwspencer/ideagdb/debug/utils/SdkUtil.java
+++ b/src/main/java/uk/co/cwspencer/ideagdb/debug/utils/SdkUtil.java
@@ -30,4 +30,14 @@ public class SdkUtil {
     public static boolean isHostOsWindows() {
         return SystemInfo.isWindows;
     }
+
+    public static boolean isWslPath(String posixPath) { return SystemInfo.isWindows && posixPath.startsWith("/mnt/"); }
+
+    public static String translateWslPosixToWindowsPath(String posixPath) {
+        return posixPath.substring(5,6) + ":/" + posixPath.substring(7);
+    }
+
+    public static String translateWslWindowsToPosixPath(String windowsPath) {
+        return "/mnt/" + windowsPath.substring(0,1).toLowerCase() + windowsPath.substring(2).replace("\\", "/");
+    }
 }

--- a/src/main/kotlin/io/github/intellij/dlanguage/project/dependencies.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/project/dependencies.kt
@@ -16,6 +16,8 @@ data class DubPackage(
     val name: String,
     val path: String,
     val version: String,
+    val targetPath: String,
+    val targetFileName: String,
     // the following can potentially be empty
     val description: String,
     val copyright: String,

--- a/src/main/kotlin/io/github/intellij/dlanguage/tools/dub/DescribeParser.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/tools/dub/DescribeParser.kt
@@ -77,6 +77,8 @@ class DescribeParserImpl : DescribeParser {
             name = json.asString("name"),
             path = json.asString("path"),
             version = json.asString("version"),
+            targetPath = json.asString("targetPath"),
+            targetFileName = json.asString("targetFileName"),
             description = json.asString("description"),
             copyright = json.asString("copyright"),
             license = json.asString("license"),


### PR DESCRIPTION
This pull requests enables MagoMI as GDB replacement on windows and also debugging linux applications on Windows using Windows Subsystem for linux.

### GDB WSL
Debugging is possible, variables are shown and stack trace is also working now. 
For testing create a batch file "dubwsl.bat" with content:
```
@ECHO OFF
wsl dub %*
```

and a batch file "gdbwsl.bat" with content:
```
@ECHO OFF
wsl gdb %*
```
Set dubwsl.bat as dub file path and gdbwsl.bat as gdb file path.

![image](https://user-images.githubusercontent.com/1451047/41791094-fc4595d2-7654-11e8-939b-07c04eb9140e.png)

![image](https://user-images.githubusercontent.com/1451047/41822453-0cd422fa-77f0-11e8-9725-4963948fef62.png)


### MagoMI

-var-update command bug is fixed and debugging is also possible now. But there are some issues with the stack trace:
- Variable content seems to be wrong
- app.d is mentioned 2 times (https://github.com/rainers/mago/issues/21) -> DMD bug?

![image](https://user-images.githubusercontent.com/1451047/41934380-e0f5bf5c-7986-11e8-8960-82e739c9131e.png)

Find newest mago-mi here
https://ci.appveyor.com/project/rainers/mago

### Additional notes

This pr also introduce the dub package fields targetPath and targetFileName. Unfortunately ```dub describe``` does not encode "/" with a "\\". This causes an Java/Kotlin JSON exception if a / is in field targetPath like "bin/". Dub describe should output "bin\\/".
There is an open issue on dub https://github.com/dlang/dub/issues/1494