### PR TITLE
Fix DCD druntime/phobos path on windows

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionServer.java
+++ b/src/main/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionServer.java
@@ -181,8 +181,12 @@ public class DCDCompletionServer implements ModuleComponent, ToolChangeListener 
                     final String root = path.replaceAll("bin", "src");
                     compilerSources.add(root + "/phobos");
                     compilerSources.add(root + "/druntime/import");
+                } else if (SystemInfo.isWindows) {
+                    final String root = path.replaceAll("windows/bin", "src");
+                    compilerSources.add(root + "/phobos");
+                    compilerSources.add(root + "/druntime/import");
                 }
-                // add linux and windows here once I know how
+                // add linux here once I know how
             }
         }
         return compilerSources;


### PR DESCRIPTION
Path has value "C:\D\dmd2\windows\bin" on windows.
Phobos is located at C:\D\dmd2\src\phobos
and druntime is located at C:\D\dmd2\src\druntime\import