### PR TITLE
Execute compile check without generating binary

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/highlighting/annotation/external/CompileCheck.java
+++ b/src/main/java/io/github/intellij/dlanguage/highlighting/annotation/external/CompileCheck.java
@@ -39,6 +39,7 @@ public class CompileCheck {
         final GeneralCommandLine cmd = new GeneralCommandLine()
             .withWorkDirectory(file.getProject().getBasePath())
             .withExePath(dubPath)
+            .withEnvironment("DFLAGS", "-o-")
             .withParameters("build", "--combined", "-q");
 
         try {


### PR DESCRIPTION
In the background IntelliJ D plugin is calling dub to check the syntax of the code. Generating binaries in this step aren't necessary and causing issues like the one mentioned in #452.

This pr disables the binary creation during syntax check. Which should have performance benefits.

Dub currently does not have a build type "syntax only" therefore DFLAGS is used. I created a pr on dub side to add build type "syntax only".