### PR TITLE
Use environment variables from dub configuration

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/run/DlangRunDubState.java
+++ b/src/main/java/io/github/intellij/dlanguage/run/DlangRunDubState.java
@@ -202,6 +202,8 @@ public class DlangRunDubState extends CommandLineState {
             cmd.addParameters(Arrays.asList(config.getAdditionalParams().split("\\s")));
         }
 
+        cmd.withEnvironment(config.getEnvVars());
+
         return cmd;
 
     }


### PR DESCRIPTION
Environment variables set in DUB configuration were not passed while starting DUB.

Solves issue https://github.com/intellij-dlanguage/intellij-dlanguage/issues/95