### PR TITLE
Fix missing return statement in GdbValue.java

### DIFF
--- a/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbValue.java
+++ b/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbValue.java
@@ -139,6 +139,7 @@ public class GdbValue extends XValue {
         if (variables.objects == null || variables.objects.isEmpty()) {
             // No data
             node.addChildren(XValueChildrenList.EMPTY, true);
+            return;
         }
 
         // Build a XValueChildrenList


### PR DESCRIPTION
The missing return statement causes runtime errors