### PR TITLE
Remove DCD special flags handling

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionServer.java
+++ b/src/main/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionServer.java
@@ -107,11 +107,7 @@ public class DCDCompletionServer implements ModuleComponent, ToolChangeListener 
         final ParametersList parametersList = commandLine.getParametersList();
 
         if (isNotNullOrEmpty(flags)) {
-            final List<String> importList = Arrays.asList(flags.split(","));
-            for (final String item : importList) {
-                parametersList.addParametersString("-I");
-                parametersList.addParametersString(item);
-            }
+            parametersList.addAll(flags);
         }
 
         // try to auto add project files in source root


### PR DESCRIPTION
This might be a major change, but I think it is necessary.

The DCD server flags field had a special handling. While the user thought he can add arguments
like described on DCD documentation, that silently failed. Instead the values entered here were
splitted by comma and added fixed with -I prefix.
That was an unexpected behavior and not consistent to the other tools (dub/dscanner/gdb/...)

With the merged pull request #460 this special behavior isn't needed anymore. Compiler sources (phobos/druntime) + additional source paths can now be easily set in SDK settings. In most cases you doesn't need to add any sources anymore as phobos and druntime paths now be retrieved from SDK.

Therefore this PR removes the special handling. Flags are now passed as arguments as expected.