### PR TITLE
DCD Server command log added

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionServer.java
+++ b/src/main/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionServer.java
@@ -143,6 +143,7 @@ public class DCDCompletionServer implements ModuleComponent, ToolChangeListener 
         }
 
         try {
+            LOG.info("DCD server start parameters " + parametersList.toString());
             process = commandLine.createProcess();
             LOG.info("DCD process started");
         } catch (final ExecutionException e) {


### PR DESCRIPTION
In case of an error with dcd it would be good to check the arguments dcd server was called with. This pr adds the dcd server arguments to the log.