### PR TITLE
Implement custom TreeStructureProvider for project view

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/psi/DlangFile.java
+++ b/src/main/java/io/github/intellij/dlanguage/psi/DlangFile.java
@@ -55,6 +55,24 @@ public class DlangFile extends PsiFileBase {
     }
 
     /**
+     * Returns the module name without parent packages, as defined in the file.
+     *
+     * If no module declaration is present, the default D module name is used
+     * (file name without extension).
+     */
+    @NotNull
+    public String getUnqualifiedModuleName() {
+        final String fullModuleName = getModuleName();
+        final String moduleName;
+        if (fullModuleName != null) {
+            moduleName = fullModuleName.substring(fullModuleName.lastIndexOf('.') + 1);
+        } else {
+            moduleName = getVirtualFile().getNameWithoutExtension();
+        }
+        return moduleName;
+    }
+
+    /**
      * Returns the module name if it exists, otherwise returns the file name.
      */
     @NotNull

--- a/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
@@ -16,6 +16,8 @@ import io.github.intellij.dlanguage.psi.DlangFile
 class DPsiFileNode(project: Project?, dFilePsi: DlangFile, viewSettings: ViewSettings) :
     AbstractPsiBasedNode<DlangFile>(project, dFilePsi, viewSettings) {
 
+    override fun getTypeSortKey(): Comparable<*> = TypeSortKey(this)
+
     override fun updateImpl(data: PresentationData) {
         val filePsi: DlangFile? = value
         if (filePsi != null) {
@@ -54,5 +56,12 @@ class DPsiFileNode(project: Project?, dFilePsi: DlangFile, viewSettings: ViewSet
         } else {
             super.getTypeSortWeight(sortByType)
         }
+    }
+
+    private class TypeSortKey(node: DPsiFileNode) : Comparable<TypeSortKey>
+    {
+        private val unqualifiedModuleName = node.value.unqualifiedModuleName
+
+        override fun compareTo(other: TypeSortKey) = unqualifiedModuleName.compareTo(other.unqualifiedModuleName)
     }
 }

--- a/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
@@ -20,14 +20,13 @@ class DPsiFileNode(project: Project?, dFilePsi: DlangFile, viewSettings: ViewSet
         val filePsi: DlangFile? = value
         if (filePsi != null) {
             val fileName = filePsi.virtualFile.nameWithoutExtension
-            val fileExt = filePsi.virtualFile.extension
             if (fileName == "package") {
-                data.addText("package.$fileExt", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+                data.addText("package.${filePsi.virtualFile.extension}", SimpleTextAttributes.REGULAR_ATTRIBUTES)
             } else {
-                val presentableModuleName = filePsi.moduleName?.split(".")?.last() ?: fileName
+                val presentableModuleName = filePsi.unqualifiedModuleName
                 val presentableFileName: String? =
                     if (fileName != presentableModuleName) {
-                        "$fileName.$fileExt"
+                        "$fileName.${filePsi.virtualFile.extension}"
                     } else {
                         null
                     }

--- a/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
@@ -1,0 +1,47 @@
+package io.github.intellij.dlanguage.projectview
+
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.projectView.ViewSettings
+import com.intellij.ide.projectView.impl.nodes.AbstractPsiBasedNode
+import com.intellij.ide.util.treeView.AbstractTreeNode
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.ui.SimpleTextAttributes
+import io.github.intellij.dlanguage.psi.DlangFile
+
+/**
+ * Each instance of this class corresponds to a D language file
+ * in the project view.
+ */
+class DPsiFileNode(project: Project?, dFilePsi: DlangFile, viewSettings: ViewSettings) :
+    AbstractPsiBasedNode<DlangFile>(project, dFilePsi, viewSettings) {
+
+    override fun updateImpl(data: PresentationData) {
+        val filePsi: DlangFile? = value
+        if (filePsi != null) {
+            val fileName = filePsi.virtualFile.nameWithoutExtension
+            val fileExt = filePsi.virtualFile.extension
+            if (fileName == "package") {
+                data.addText("package.$fileExt", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+            } else {
+                val presentableModuleName = filePsi.moduleName?.split(".")?.last() ?: fileName
+                val presentableFileName: String? =
+                    if (fileName != presentableModuleName) {
+                        "$fileName.$fileExt"
+                    } else {
+                        null
+                    }
+
+                data.addText("$presentableModuleName   ", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+                presentableFileName?.let { data.addText(ColoredFragment(it, SimpleTextAttributes.GRAYED_ATTRIBUTES)) }
+            }
+        }
+    }
+
+    override fun getChildrenImpl(): Collection<AbstractTreeNode<*>> {
+        // TODO: Eventually the plugin could support the "Show Members" feature of the project view.
+        return emptyList()
+    }
+
+    override fun extractPsiFromValue(): PsiElement? = value
+}

--- a/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
@@ -44,4 +44,16 @@ class DPsiFileNode(project: Project?, dFilePsi: DlangFile, viewSettings: ViewSet
     }
 
     override fun extractPsiFromValue(): PsiElement? = value
+
+    override fun getTypeSortWeight(sortByType: Boolean): Int {
+        return if (sortByType) {
+            if (value?.virtualFile?.nameWithoutExtension == "package") {
+                1
+            } else {
+                0
+            }
+        } else {
+            super.getTypeSortWeight(sortByType)
+        }
+    }
 }

--- a/src/main/kotlin/io/github/intellij/dlanguage/projectview/DTreeStructureProvider.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/projectview/DTreeStructureProvider.kt
@@ -1,0 +1,35 @@
+package io.github.intellij.dlanguage.projectview
+
+import com.intellij.ide.projectView.TreeStructureProvider
+import com.intellij.ide.projectView.ViewSettings
+import com.intellij.ide.projectView.impl.nodes.PsiFileNode
+import com.intellij.ide.util.treeView.AbstractTreeNode
+
+/**
+ * Modifies the Project View tree to better fit the D workflow and to take
+ * advantage of features offered by the IDEA plugin API.
+ *
+ * D source files get their own special node type here ([DPsiFileNode]).
+ *
+ * Based on the Kotlin plugin's Project TreeStructureProvider:
+ * [https://github.com/JetBrains/kotlin/blob/26413acf33a86375e1c63b9dae9fdefbe75b0561/idea/src/org/jetbrains/kotlin/idea/projectView/projectViewProviders.kt]
+ */
+class DTreeStructureProvider : TreeStructureProvider {
+    override fun modify(parent: AbstractTreeNode<*>,
+                        children: MutableCollection<AbstractTreeNode<*>>,
+                        settings: ViewSettings): Collection<AbstractTreeNode<*>> {
+
+        return children.map { child ->
+            if (child is PsiFileNode) {
+                val dlangFile = child.dlangFile
+                if (dlangFile != null) {
+                    DPsiFileNode(child.project, dlangFile, settings)
+                } else {
+                    child
+                }
+            } else {
+                child
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/github/intellij/dlanguage/projectview/ProjectViewUtil.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/projectview/ProjectViewUtil.kt
@@ -1,0 +1,16 @@
+package io.github.intellij.dlanguage.projectview
+
+import com.intellij.ide.projectView.impl.nodes.PsiFileNode
+import com.intellij.psi.PsiManager
+import io.github.intellij.dlanguage.psi.DlangFile
+
+/**
+ * Returns the [DlangFile] associated with this [PsiFileNode], or
+ * `null` if at least one of the following is true for this node:
+ *
+ *  - Not part of a project.
+ *  - Has no associated [VirtualFile][com.intellij.openapi.vfs.VirtualFile].
+ *  - Not a D source file.
+ */
+val PsiFileNode.dlangFile: DlangFile?
+    get() = this.project?.let { p -> virtualFile?.let { vf -> PsiManager.getInstance(p).findFile(vf) } } as? DlangFile

--- a/src/main/resources/META-INF/idea-only.xml
+++ b/src/main/resources/META-INF/idea-only.xml
@@ -13,6 +13,10 @@
         <projectImportProvider implementation="io.github.intellij.dlanguage.project.DubProjectImportProvider"/>
         <projectImportBuilder implementation="io.github.intellij.dlanguage.project.DubProjectImportBuilder"/>
         <projectOpenProcessor id="DubProjectOpenProcessor" implementation="io.github.intellij.dlanguage.project.DubProjectOpenProcessor"/>
+
+        <!-- Project Tree View -->
+        <treeStructureProvider implementation="io.github.intellij.dlanguage.projectview.DTreeStructureProvider"/>
+
     </extensions>
 
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -236,6 +236,8 @@
         <!-- Structure View -->
         <lang.psiStructureViewFactory language="D" implementationClass="io.github.intellij.dlanguage.structure.DStructureViewFactory"/>
 
+        <!-- Project Tree View -->
+        <treeStructureProvider implementation="io.github.intellij.dlanguage.projectview.DTreeStructureProvider"/>
 
         <postStartupActivity
             implementation="io.github.intellij.dlanguage.project.DubListenerComponent"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -236,8 +236,6 @@
         <!-- Structure View -->
         <lang.psiStructureViewFactory language="D" implementationClass="io.github.intellij.dlanguage.structure.DStructureViewFactory"/>
 
-        <!-- Project Tree View -->
-        <treeStructureProvider implementation="io.github.intellij.dlanguage.projectview.DTreeStructureProvider"/>
 
         <postStartupActivity
             implementation="io.github.intellij.dlanguage.project.DubListenerComponent"/>


### PR DESCRIPTION
This fixes #372 and should make it easier to customize the project view tree in the future.

In the new project view:
- The text shown for each D source file is the unqualified module name, instead of the fully qualified module name.
- If the module name and file name differ, both are shown (with the file name in grey).
- `package.d` files are shown with that name, rather than the module name.
- When "Sort by Type" is enabled, `package.d` files are listed at the top of their directory. All other files are sorted alphabetically by module name.

Side-by-side comparison, before and after:

![image](https://user-images.githubusercontent.com/7419746/52158674-a9875000-264f-11e9-8fef-36a89d19c1be.png)
![image](https://user-images.githubusercontent.com/7419746/52158688-ccb1ff80-264f-11e9-9fa0-e96d44ce24bd.png)

Note that `test.d` and `example.d` have no explicit module declaration, so their fully qualified module names are `test` and `example` respectively.

The rename and file creation actions have the same issues as before (#388 and #404) but I'm hoping this change might make it a bit easier to tackle those two.

I'm new to IntelliJ plugin development and the official docs are pretty lacking in this department, so hopefully this hasn't horribly broken anything. I mostly based it on the Kotlin plugin's implementation of these files.

Possible future work could include supporting the "Show Members" option of the project view and implementing specialized refactor actions for files which only contain a single declaration (class/interface/etc.), like how the IDE behaves for Java and Kotlin class files.