### PR TITLE
fix #526 - add 'arch' capture group to regex in parseFrameLine

### DIFF
--- a/debugger/src/main/java/uk/co/cwspencer/gdb/gdbmi/GdbMiParser2.java
+++ b/debugger/src/main/java/uk/co/cwspencer/gdb/gdbmi/GdbMiParser2.java
@@ -86,7 +86,8 @@ public class GdbMiParser2 {
             "(?:file=\"(?<file>[^\"]+)\")?,?" +
             "(?:fullname=\"(?<fullname>[^\"]+)\")?,?" +
             "(?:line=\"(?<line>\\d+)\")?,?" +
-            "(?:from=\"(?<from>[^\"]+)\")?" +
+            "(?:from=\"(?<from>[^\"]+)\")?,?" +
+            "(?:arch=\"(?<arch>.*)\")?" +
             "\\}";
 
         final Pattern p = Pattern.compile(pattern);
@@ -153,10 +154,17 @@ public class GdbMiParser2 {
                 frameVal.tuple.add(fromVal);
             }
 
+            // arch="i386:x86-64"
+            if(m.group("arch") != null) {
+                GdbMiResult archVal = new GdbMiResult("arch");
+                archVal.value.type = GdbMiValue.Type.String;
+                archVal.value.string = m.group("arch");
+                frameVal.tuple.add(archVal);
+            }
+
             subRes.value = frameVal;
             result.add(subRes);
         }
-
         return result;
     }
 


### PR DESCRIPTION
This probably shouldn't be merged yet as it's only been tested on linux using GDB 8.3.1
It fixes #526 for me, however I'm unsure if this will have effect on mago-mi or gdb on macOS.

This PR removes "level" and "from" from the regex in `parseFrameLine`.  It also adds "arch" to the regex since that is included in the `line` as I'm seeing it.  I wanted to open this for review.  I will try to test this on Windows and macOS in the meantime to make sure it doesnt break anything else.

Thanks for your time!
