### PR TITLE
Fix incorrect class binding for GdbConsoleView.form

### DIFF
--- a/debugger/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbConsoleView.form
+++ b/debugger/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbConsoleView.form
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="uk.co.cwspencer.debug.GdbConsoleView">
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="uk.co.cwspencer.ideagdb.debug.GdbConsoleView">
   <grid id="27dc6" binding="m_contentPanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>


### PR DESCRIPTION
The recent multimodule change broke the Gdb Console View becase the path to the class GdbConsoleView changed.