### PR TITLE
SwitchToNewAliasSyntax quickfix: make sure to trim the alias name.

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/quickfix/SwitchToNewAliasSyntax.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/quickfix/SwitchToNewAliasSyntax.kt
@@ -19,7 +19,7 @@ class SwitchToNewAliasSyntax(elem: DLanguageAliasDeclaration) : LocalQuickFixOnP
         val restStartIndex = aliasDecl.type!!.textRange.endOffset
         val restEndIndex = aliasDecl.textRange.endOffset
         val restText = aliasDecl.text.substring(restStartIndex - aliasStartIndex, restEndIndex - aliasStartIndex)
-        val newAliasString = "alias " + restText.replace(";", "") + " = " + type!!.text + ";"
+        val newAliasString = "alias " + restText.replace(";", "").trim() + " = " + type!!.text + ";"
         aliasDecl.replace(DElementFactory.createAliasDeclarationFromText(project, newAliasString))
     }
 

--- a/src/test/kotlin/io/github/intellij/dlanguage/quickfix/DQuickFixTestBase.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/quickfix/DQuickFixTestBase.kt
@@ -1,0 +1,10 @@
+package io.github.intellij.dlanguage.quickfix
+
+import com.intellij.codeInsight.daemon.quickFix.LightQuickFixTestCase
+
+abstract class DQuickFixTestBase : LightQuickFixTestCase() {
+    override fun getTestDataPath(): String {
+        return this.javaClass.classLoader.getResource("gold/quickfix/")!!.path
+    }
+}
+

--- a/src/test/kotlin/io/github/intellij/dlanguage/quickfix/SwitchToNewAliasSyntaxTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/quickfix/SwitchToNewAliasSyntaxTest.kt
@@ -1,0 +1,15 @@
+package io.github.intellij.dlanguage.quickfix
+
+import io.github.intellij.dlanguage.inspections.OldAliasSyntax
+
+class SwitchToNewAliasSyntaxTest : DQuickFixTestBase() {
+    override fun setUp() {
+        super.setUp()
+        enableInspectionTools(OldAliasSyntax())
+    }
+
+    fun test() {
+        doSingleTest("SwitchToNewAlias.d")
+    }
+}
+

--- a/src/test/resources/gold/quickfix/afterSwitchToNewAlias.d
+++ b/src/test/resources/gold/quickfix/afterSwitchToNewAlias.d
@@ -1,0 +1,2 @@
+// "Switch to new alias syntax" "true"
+alias vec3 = Vector!(float, 3);

--- a/src/test/resources/gold/quickfix/beforeSwitchToNewAlias.d
+++ b/src/test/resources/gold/quickfix/beforeSwitchToNewAlias.d
@@ -1,0 +1,2 @@
+// "Switch to new alias syntax" "true"
+alias Vector!(float, 3) vec3;<caret>


### PR DESCRIPTION
When running the `SwitchToNewAliasSyntax` quickfix, a declaration like
```d
alias Vector!(float, 3) vec3;
```
would be converted to
```d
alias  vec3 = Vector!(float, 3);
     ^^
```
This change removes the extra space preceeding the alias name.