### PR TITLE
Formatter: don't format function call args with a leading space

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/features/formatter/DFormattingModelBuilder.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/features/formatter/DFormattingModelBuilder.kt
@@ -27,7 +27,7 @@ class DFormattingModelBuilder : FormattingModelBuilder {
 
     private fun createSpacingBuilder(settings: CodeStyleSettings): SpacingBuilder {
         return SpacingBuilder(settings, DLanguage)
-            .withinPair(KW_CASE, ARGUMENT_LIST).spaces(1)
+            .between(KW_CASE, ARGUMENT_LIST).spaces(1)
             .before(COMMA).spaceIf(false)
             .after(COMMA).spaceIf(true)
             .before(SEMICOLON).spaceIf(false)

--- a/src/test/java/io/github/intellij/dlanguage/formatting/DFormatterTest.java
+++ b/src/test/java/io/github/intellij/dlanguage/formatting/DFormatterTest.java
@@ -1,12 +1,9 @@
 package io.github.intellij.dlanguage.formatting;
 
-
 import com.intellij.psi.formatter.FormatterTestCase;
 import io.github.intellij.dlanguage.DlangFileType;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Ignore;
 
-@Ignore
 public class DFormatterTest extends FormatterTestCase {
     @NotNull
     @Override
@@ -35,14 +32,14 @@ public class DFormatterTest extends FormatterTestCase {
     public void testDeclSpacing() throws Exception {
         doTest();
     }
-//
-public void testattribute_constraint() throws Exception {
-    doTest();
-}
 
-public void testdlanguage_issue_497() throws  Exception{
+    public void testattribute_constraint() throws Exception {
         doTest();
-}
+    }
+
+    public void testdlanguage_issue_497() throws Exception {
+        doTest();
+    }
 
 //
 //    public void testbreakOnDots() throws Exception {

--- a/src/test/resources/gold/formatting/dlanguage_issue_497-after.d
+++ b/src/test/resources/gold/formatting/dlanguage_issue_497-after.d
@@ -1,7 +1,7 @@
 import std.stdio;
 
 void main(string[] args){
-    switch(i){
+    switch (i){
         case 1: writeln(i);
     }
 }


### PR DESCRIPTION
Previous formatting behavior was to format
```d
foo(a, b, c);
```
as
```d
foo( a, b, c);
    ^ 
```

This was slightly surprising, especially as it is the result of a rule which appears to be intended to format switch statements. 

Ideally we'd probably support spacing options similar to the Java formatter, which lets you choose between `foo(x)`
and `foo( x )` though if there are strong feelings about keeping the current behavior then let's discuss.
