### PR TITLE
Fix/sorting files

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
@@ -2,10 +2,11 @@ package io.github.intellij.dlanguage.projectview
 
 import com.intellij.ide.projectView.PresentationData
 import com.intellij.ide.projectView.ViewSettings
-import com.intellij.ide.projectView.impl.nodes.AbstractPsiBasedNode
+import com.intellij.ide.projectView.impl.nodes.BasePsiNode
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.psi.PsiFile
 import com.intellij.ui.SimpleTextAttributes
 import io.github.intellij.dlanguage.psi.DlangFile
 
@@ -14,13 +15,25 @@ import io.github.intellij.dlanguage.psi.DlangFile
  * in the project view.
  */
 class DPsiFileNode(project: Project?, dFilePsi: DlangFile, viewSettings: ViewSettings) :
-    AbstractPsiBasedNode<DlangFile>(project, dFilePsi, viewSettings) {
+    BasePsiNode<DlangFile>(project, dFilePsi, viewSettings) {
 
     override fun getTypeSortKey(): Comparable<*> = TypeSortKey(this)
+
+    override fun getTitle(): String? {
+        return if (virtualFile != null) FileUtil.getLocationRelativeToUserHome(virtualFile!!.presentableUrl) else super.getTitle()
+    }
+
+    override fun canRepresent(element: Any?): Boolean {
+        if (super.canRepresent(element)) return true
+
+        val value: DlangFile? = value
+        return value != null && element != null && element == value.virtualFile
+    }
 
     override fun updateImpl(data: PresentationData) {
         val filePsi: DlangFile? = value
         if (filePsi != null) {
+            data.presentableText = value.getModuleName()
             val fileName = filePsi.virtualFile.nameWithoutExtension
             if (fileName == "package") {
                 data.addText("package.${filePsi.virtualFile.extension}", SimpleTextAttributes.REGULAR_ATTRIBUTES)
@@ -43,8 +56,6 @@ class DPsiFileNode(project: Project?, dFilePsi: DlangFile, viewSettings: ViewSet
         // TODO: Eventually the plugin could support the "Show Members" feature of the project view.
         return emptyList()
     }
-
-    override fun extractPsiFromValue(): PsiElement? = value
 
     override fun getTypeSortWeight(sortByType: Boolean): Int {
         return if (sortByType) {

--- a/src/main/kotlin/io/github/intellij/dlanguage/projectview/DTreeStructureProvider.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/projectview/DTreeStructureProvider.kt
@@ -4,6 +4,7 @@ import com.intellij.ide.projectView.TreeStructureProvider
 import com.intellij.ide.projectView.ViewSettings
 import com.intellij.ide.projectView.impl.nodes.PsiFileNode
 import com.intellij.ide.util.treeView.AbstractTreeNode
+import com.intellij.openapi.project.DumbAware
 
 /**
  * Modifies the Project View tree to better fit the D workflow and to take
@@ -14,7 +15,7 @@ import com.intellij.ide.util.treeView.AbstractTreeNode
  * Based on the Kotlin plugin's Project TreeStructureProvider:
  * [https://github.com/JetBrains/kotlin/blob/26413acf33a86375e1c63b9dae9fdefbe75b0561/idea/src/org/jetbrains/kotlin/idea/projectView/projectViewProviders.kt]
  */
-class DTreeStructureProvider : TreeStructureProvider {
+class DTreeStructureProvider : TreeStructureProvider, DumbAware {
     override fun modify(parent: AbstractTreeNode<*>,
                         children: MutableCollection<AbstractTreeNode<*>>,
                         settings: ViewSettings): Collection<AbstractTreeNode<*>> {


### PR DESCRIPTION
The actual fix is to set the presentable name, also improved a bit the DPsiFileNode
closes #674 

After changes:
![image](https://user-images.githubusercontent.com/9578950/172051530-27b0a63a-882c-4516-a4af-e05ab93731cc.png)
