### PR TITLE
Replace deprecated getRootModel by getModifiableRootModel

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/module/DlangModuleEditorsProvider.java
+++ b/src/main/java/io/github/intellij/dlanguage/module/DlangModuleEditorsProvider.java
@@ -17,7 +17,7 @@ public class DlangModuleEditorsProvider implements ModuleConfigurationEditorProv
 
     @Override
     public ModuleConfigurationEditor[] createEditors(final ModuleConfigurationState state) {
-        final Module module = state.getRootModel().getModule();
+        final Module module = state.getModifiableRootModel().getModule();
         if (ModuleType.get(module) != DlangModuleType.getInstance()) {
             return ModuleConfigurationEditor.EMPTY;
         }


### PR DESCRIPTION
getRootModel will be removed in the next version 2022.2