### PR TITLE
722: fix null pointer exception while parsing a dmd test

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/parser/DLangParser.java
+++ b/src/main/java/io/github/intellij/dlanguage/parser/DLangParser.java
@@ -6893,6 +6893,11 @@ class DLangParser {
      */
     boolean parseStatementNoCaseNoDefault() {
         final Marker m = enter_section_modified(builder);
+        if (!moreTokens()) {
+            error("Expected statement instead of EOF");
+            exit_section_modified(builder, m, STATEMENT_NO_CASE_NO_DEFAULT, true);
+            return false;
+        }
         final Token.IdType i = current().type;
         if (i.equals(tok("{"))) {
             if (!parseBlockStatement()) {

--- a/src/test/java/io/github/intellij/dlanguage/parser/DLanguageParserTest.java
+++ b/src/test/java/io/github/intellij/dlanguage/parser/DLanguageParserTest.java
@@ -1094,6 +1094,11 @@ public class DLanguageParserTest extends DLanguageParserTestBase {
         doDlangParserTest(true, true);
     }
 
+    // dmd fail_compilation test file
+    public void teste15876_1() {
+        doDlangParserTest(true, false);
+    }
+
 // standard library
 
     public void teststdio() {

--- a/src/test/resources/gold/parser/e15876_1.d
+++ b/src/test/resources/gold/parser/e15876_1.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/e15876_1.d(15): Error: valid scope identifiers are `exit`, `failure`, or `success`, not `x`
+fail_compilation/e15876_1.d(16): Error: found `End of File` when expecting `)`
+fail_compilation/e15876_1.d(16): Error: found `End of File` instead of statement
+fail_compilation/e15876_1.d(16): Error: found `End of File` when expecting `}` following compound statement
+fail_compilation/e15876_1.d(16): Error: found `End of File` when expecting `]`
+fail_compilation/e15876_1.d(16): Error: no identifier for declarator `o[()
+{
+scope(exit) }
+]`
+---
+*/
+o[{scope(x

--- a/src/test/resources/gold/parser/expected/e15876_1.txt
+++ b/src/test/resources/gold/parser/expected/e15876_1.txt
@@ -1,0 +1,17 @@
+D Language File
+  PsiComment(DlangTokenType.BLOCK_COMMENT)('/*\nTEST_OUTPUT:\n---\nfail_compilation/e15876_1.d(15): Error: valid scope identifiers are `exit`, `failure`, or `success`, not `x`\nfail_compilation/e15876_1.d(16): Error: found `End of File` when expecting `)`\nfail_compilation/e15876_1.d(16): Error: found `End of File` instead of statement\nfail_compilation/e15876_1.d(16): Error: found `End of File` when expecting `}` following compound statement\nfail_compilation/e15876_1.d(16): Error: found `End of File` when expecting `]`\nfail_compilation/e15876_1.d(16): Error: no identifier for declarator `o[()\n{\nscope(exit) }\n]`\n---\n*/')
+  DLanguageDeclarationImpl(DECLARATION)
+    DLanguageTypeImpl(TYPE)
+      DLanguageType_2Impl(TYPE_2)
+        DLanguageTypeIdentifierPartImpl(TYPE_IDENTIFIER_PART)
+          DLanguageIdentifierOrTemplateInstanceImpl(IDENTIFIER_OR_TEMPLATE_INSTANCE)
+            IDENTIFIER
+              PsiElement(DlangTokenType.ID)('o')
+    PsiErrorElement:no identifier for declarator
+      <empty list>
+    PsiElement(DlangTokenType.[)('[')
+    PsiElement(DlangTokenType.{)('{')
+    PsiElement(DlangTokenType.scope)('scope')
+    PsiElement(DlangTokenType.()('(')
+    IDENTIFIER
+      PsiElement(DlangTokenType.ID)('x')


### PR DESCRIPTION
fix parsing of ~test/fail_compilation/e15876_3.d~ test/fail_compilation/e15876_1.d
Closes #722 