### PR TITLE
#723: Add support for alias types in the syntax highlighter

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/lexer/DSyntaxHighlightingLexer.flex
+++ b/src/main/java/io/github/intellij/dlanguage/lexer/DSyntaxHighlightingLexer.flex
@@ -153,10 +153,14 @@ BASIC_TYPES = ( bool |
                 creal |
                 auto |
                 enum |
-                string |
-                void )
+                void)
+ALIASED_TYPES = (string |
+                size_t |
+                ptrdiff_t |
+                noreturn)
 
 KEYWORD = ({BASIC_TYPES} |
+           {ALIASED_TYPES} |
            module |
            import |
            static |


### PR DESCRIPTION
Closes #723 