### PR TITLE
Fix annotation ending when string delimiter has a string postfix

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/annotator/DStringLiteralAnnotator.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/annotator/DStringLiteralAnnotator.kt
@@ -20,7 +20,8 @@ class DStringLiteralAnnotator : Annotator {
         if (element !is PrimaryExpression) return
         if (element.delimiteD_STRINGs.isNotEmpty()) {
             for (elem in element.delimiteD_STRINGs) {
-                val value = elem.text.substring(2, elem.textLength - 1) // Skip `q"` and `"`
+                val endPos = if (elem.text[elem.textLength - 1] == '"')  1 else 2;
+                val value = elem.text.substring(2, elem.textLength - endPos) // Skip `q"` and `"`
                 val openingDelimiter = getOpeningDelimiter(value)
                 if (openingDelimiter == null) {
                     when {

--- a/src/test/resources/gold/highlighting/annotator/invalid_string_delimiters.d
+++ b/src/test/resources/gold/highlighting/annotator/invalid_string_delimiters.d
@@ -6,3 +6,4 @@ enum a = <error descr="Delimiter cannot be whitespace">q"   test    "</error>;
 enum a = <error descr="Invalid string delimiter">q"test"</error>;
 enum a = <error descr="Invalid string delimiter">q"ùtestù"</error>;
 enum a = q"/test/<error descr="Illegal text found after closing delimiter, expected \" character instead">foo/</error>";
+enum a = q"/test/<error descr="Illegal text found after closing delimiter, expected \" character instead">foo/</error>"d;


### PR DESCRIPTION
Previously, the implementation was blindly considering that the last
character was always '"'. It’s actually a wrong assumption as a string
postfix can be added (c, w, d). The code now consider this and the error
annotation won’t highlight the '"' character even with postfix.

Related to #751 