### PR TITLE
 #771 fix multiline comments breaking highlighting

### DIFF
--- a/src/main/jflex/io/github/intellij/dlanguage/lexer/DLanguageLexer.flex
+++ b/src/main/jflex/io/github/intellij/dlanguage/lexer/DLanguageLexer.flex
@@ -500,6 +500,11 @@ NESTING_BLOCK_DOC_END = "+/"
             return DlangTypes.NESTING_BLOCK_COMMENT;
         }
     }
+    <<EOF>>	{
+        yybegin(YYINITIAL); //Exit nesting comment block
+        return DlangTypes.NESTING_BLOCK_COMMENT;
+    }
+
     \/\/        {}
     \n|\/|\+    {}
     [^/+\n]+    {}
@@ -509,6 +514,10 @@ NESTING_BLOCK_DOC_END = "+/"
     {BLOCK_COMMENT_START} {}
 
     \/? {BLOCK_COMMENT_END} {
+        yybegin(YYINITIAL);
+        return DlangTypes.BLOCK_COMMENT;
+    }
+    <<EOF>> {
         yybegin(YYINITIAL);
         return DlangTypes.BLOCK_COMMENT;
     }
@@ -534,6 +543,10 @@ NESTING_BLOCK_DOC_END = "+/"
             return DlangTypes.NESTING_BLOCK_DOC;
         }
     }
+    <<EOF>> {
+        yybegin(YYINITIAL); //Exit nesting doc block
+        return DlangTypes.NESTING_BLOCK_DOC;
+    }
     \/\/        {}
     \n|\/|\+    {}
     [^/+\n]+    {}
@@ -544,6 +557,10 @@ NESTING_BLOCK_DOC_END = "+/"
     }
 
     \/? {BLOCK_DOC_END}	{
+       yybegin(YYINITIAL);
+       return DlangTypes.BLOCK_DOC;
+    }
+    <<EOF>>	{
        yybegin(YYINITIAL);
        return DlangTypes.BLOCK_DOC;
     }

--- a/src/main/kotlin/io/github/intellij/dlanguage/annotator/DUnclosedCommentAnnotator.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/annotator/DUnclosedCommentAnnotator.kt
@@ -1,0 +1,28 @@
+package io.github.intellij.dlanguage.annotator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.suggested.endOffset
+import io.github.intellij.dlanguage.DLanguage
+
+/**
+ * Detect if a comment is not closed and annotate with error if that’s the case.
+ */
+class DUnclosedCommentAnnotator : Annotator {
+
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        if (element !is PsiComment || element.language !is DLanguage) return
+        if (element.text.startsWith("/*") && !element.text.endsWith("*/") ||
+            element.text.startsWith("/+") && (!element.text.endsWith("+/") ||
+            element.text.split("/+").size != element.text.split("+/").size)) {
+            val start = element.endOffset - 1
+            val end = start + 1
+            holder.newAnnotation(HighlightSeverity.ERROR, "Unclosed comment")
+                .range(TextRange(start, end)).create()
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -74,6 +74,7 @@
 
         <annotator language="D" implementationClass="io.github.intellij.dlanguage.annotator.DHighlightingAnnotator"/>
         <annotator language="D" implementationClass="io.github.intellij.dlanguage.annotator.DStringLiteralAnnotator"/>
+        <annotator language="D" implementationClass="io.github.intellij.dlanguage.annotator.DUnclosedCommentAnnotator"/>
         <externalAnnotator language="D"
                            implementationClass="io.github.intellij.dlanguage.highlighting.annotation.external.DExternalAnnotator"/>
         <lang.documentationProvider language="D"

--- a/src/test/java/io/github/intellij/dlanguage/highlighting/DlangHighlightingLexerTest.java
+++ b/src/test/java/io/github/intellij/dlanguage/highlighting/DlangHighlightingLexerTest.java
@@ -107,6 +107,9 @@ public class DlangHighlightingLexerTest extends DHighlightingLexerTestBase {
     public void testcomment_multi() { doTest(true, true); }
     public void testcomment_nested() { doTest(true, true); }
 
+    // Ensure that the parser don’t crash if a comment is unclosed
+    public void testcomment_unclosed() { doTest("/* unclosed comment", "DlangTokenType.BLOCK_COMMENT ('/* unclosed comment')", createLexer()); }
+
     // floats
     public void testfloat_decimal() { doTest(true, true); }
     public void testfloat_hex() { doTest(true, true); }

--- a/src/test/kotlin/io/github/intellij/dlanguage/annotator/DHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/annotator/DHighlightingAnnotatorTest.kt
@@ -15,4 +15,9 @@ class DHighlightingAnnotatorTest : BasePlatformTestCase() {
         myFixture.configureByFile("invalid_string_delimiters.d")
         myFixture.testHighlighting(false, false, false);
     }
+
+    fun testUnclosedComment() {
+        myFixture.configureByFile("unclosed_comment.d")
+        myFixture.testHighlighting(false, false, false);
+    }
 }

--- a/src/test/kotlin/io/github/intellij/dlanguage/lexer/DlangLexerTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/lexer/DlangLexerTest.kt
@@ -102,6 +102,9 @@ class DlangLexerTest : DlangLexerTestBase("lexer") {
     fun testcomment_multi() = doTest()
     fun testcomment_nested() = doTest()
 
+    // Ensure that the parser don’t crash if a comment is unclosed
+    fun testcomment_unclosed() = doTest("/* unclosed comment", "DlangTokenType.BLOCK_COMMENT ('/* unclosed comment')")
+
 
     // floats
     fun testfloat_decimal() = doTest()

--- a/src/test/resources/gold/highlighting/annotator/unclosed_comment.d
+++ b/src/test/resources/gold/highlighting/annotator/unclosed_comment.d
@@ -1,0 +1,6 @@
+
+/+
+ First level
+/+
+ Second level
++<error descr="Unclosed comment">/</error>

--- a/src/test/resources/gold/parser/expected/statements_unterminated_if.txt
+++ b/src/test/resources/gold/parser/expected/statements_unterminated_if.txt
@@ -20,6 +20,7 @@ D Language File
                   DLanguageStatementNoCaseNoDefaultImpl(STATEMENT_NO_CASE_NO_DEFAULT)
                     DLanguageIfStatementImpl(IF_STATEMENT)
                       PsiElement(DlangTokenType.if)('if')
-                      PsiElement(DlangTokenType.()('(/*Comment started\n}')
+                      PsiElement(DlangTokenType.()('(')
             PsiErrorElement:Expected } instead of EOF
               <empty list>
+    PsiComment(DlangTokenType.BLOCK_COMMENT)('/*Comment started\n}')


### PR DESCRIPTION
Due to end of file not being handle in some state, the lexer was left in non initial state leading to errors.

Close #771 