### PR TITLE
Minor changes, no behavior change is expected

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/psi/DTokenSets.java
+++ b/src/main/java/io/github/intellij/dlanguage/psi/DTokenSets.java
@@ -18,11 +18,6 @@ public class DTokenSets {
     public static final TokenSet DOCS = TokenSet.orSet(LINE_DOCS, BLOCK_DOCS);
 
     public static final TokenSet STRING_LITERALS = TokenSet.create(DlangTypes.DOUBLE_QUOTED_STRING,
-        DlangTypes.KW_CHAR,
-        DlangTypes.KW_DCHAR,
-        DlangTypes.KW_WCHAR,
-//            DlangTypes.STRING_LITERAL,
-//            DlangTypes.STRING_LITERALS,
         DlangTypes.CHARACTER_LITERAL,
         DlangTypes.DELIMITED_STRING,
         DlangTypes.WYSIWYG_STRING,

--- a/src/main/kotlin/io/github/intellij/dlanguage/DLanguage.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/DLanguage.kt
@@ -28,6 +28,7 @@ import com.intellij.psi.tree.TokenSet.orSet
 import com.intellij.ui.EditorNotificationPanel
 import io.github.intellij.dlanguage.index.DModuleIndex.getFilesByModuleName
 import io.github.intellij.dlanguage.parser.ParserWrapper
+import io.github.intellij.dlanguage.psi.DTokenSets.STRING_LITERALS
 import io.github.intellij.dlanguage.psi.DlangFile
 import io.github.intellij.dlanguage.psi.DlangTypes
 import io.github.intellij.dlanguage.resolve.processors.basic.BasicResolve
@@ -226,10 +227,10 @@ class DLangParserDefinition : ParserDefinition {
 
     override fun createFile(viewProvider: FileViewProvider): PsiFile = DlangFile(viewProvider)
 
-    override fun spaceExistanceTypeBetweenTokens(left: ASTNode?, right: ASTNode?): ParserDefinition.SpaceRequirements = ParserDefinition.SpaceRequirements.MAY
+    override fun spaceExistenceTypeBetweenTokens(left: ASTNode?, right: ASTNode?): ParserDefinition.SpaceRequirements = ParserDefinition.SpaceRequirements.MAY
 
     @NotNull
-    override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY
+    override fun getStringLiteralElements(): TokenSet = STRING_LITERALS
 
     override fun getFileNodeType(): DFileStubElementType = DFileStubElementType.INSTANCE
 


### PR DESCRIPTION
Replace deprecated method name by his new correct name.
Fix STRING_LITERAL token set.
set real value to getStringLiteralElements().