### PR TITLE
#835: Fix the run icon in DubToolWindow to correctly start the dub runner

### DIFF
--- a/dub/src/main/kotlin/io/github/intellij/dub/actions/DubBuildAction.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/actions/DubBuildAction.kt
@@ -30,7 +30,8 @@ class DubBuildAction : DubAction("_Run Dub", "", AllIcons.Actions.Execute) {
             var runDubSettings = runManager.findConfigurationByName(configName)
 
             if (runDubSettings == null) {
-                val runDubConfigurationType = ConfigurationType.CONFIGURATION_TYPE_EP.findExtensionOrFail(DlangRunDubConfigurationType::class.java)
+                val runDubConfigurationType = ConfigurationType.CONFIGURATION_TYPE_EP.findExtensionOrFail(
+                    DlangRunDubConfigurationType::class.java)
                 val factory = runDubConfigurationType.configurationFactories[0]
                 runDubSettings = runManager.createConfiguration(configName, factory)
 
@@ -46,7 +47,7 @@ class DubBuildAction : DubAction("_Run Dub", "", AllIcons.Actions.Execute) {
                         .find { module -> module.name == projectName }
                         ?.let { config.setModule(it) }
 
-                runManager.addConfiguration(runDubSettings, false)
+                runManager.addConfiguration(runDubSettings)
             }
 
             runManager.selectedConfiguration = runDubSettings
@@ -55,7 +56,8 @@ class DubBuildAction : DubAction("_Run Dub", "", AllIcons.Actions.Execute) {
             val dubBuildRunner = ProgramRunner.PROGRAM_RUNNER_EP.findExtensionOrFail(
                 DubBuildRunner::class.java)
             val env = ExecutionEnvironment(DefaultRunExecutor(), dubBuildRunner, runDubSettings, it)
-            dubBuildRunner.execute(env) { LOG.info("DubBuildRunner started") }
+            env.setCallback { LOG.info("DubBuildRunner started") }
+            dubBuildRunner.execute(env)
         }
 
     }

--- a/dub/src/main/kotlin/io/github/intellij/dub/run/DubBuildRunner.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/run/DubBuildRunner.kt
@@ -1,6 +1,7 @@
 package io.github.intellij.dub.run
 
 import com.intellij.execution.ExecutionException
+import com.intellij.execution.ExecutionManager
 import com.intellij.execution.Executor
 import com.intellij.execution.configurations.RunProfile
 import com.intellij.execution.configurations.RunProfileState
@@ -52,7 +53,8 @@ class DubBuildRunner : GenericProgramRunner<DubBuildRunner.DubBuildSettings>() {
             }
             return RunUtil.startDebugger(this, state, environment, project, executor, executableFilePath)
         }
-        return super.doExecute(state, environment)
+        val result = state.execute(environment.executor, this) ?: return null
+        return RunContentDescriptor(result.executionConsole, result.processHandler, result.executionConsole.component, environment.runProfile.name)
     }
 
     class DubBuildSettings : RunnerSettings {

--- a/dub/src/main/kotlin/io/github/intellij/dub/toolwindow/DubToolWindowPanel.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/toolwindow/DubToolWindowPanel.kt
@@ -1,7 +1,6 @@
 package io.github.intellij.dub.toolwindow
 
 import com.intellij.execution.RunnerAndConfigurationSettings
-import com.intellij.execution.configurations.ConfigurationType
 import com.intellij.execution.impl.RunManagerImpl
 import com.intellij.icons.AllIcons
 import com.intellij.ide.projectView.ViewSettings


### PR DESCRIPTION
Closes #835 
Now, the run button correctly launch the application