### PR TITLE
Fix #790 no read access in EDT, scope parameter in foreach and dformat action taking too long

### DIFF
--- a/dub/src/main/kotlin/io/github/intellij/dub/actions/ProcessDLibs.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/actions/ProcessDLibs.kt
@@ -204,7 +204,11 @@ class ProcessDLibs : AnAction("Process D Libraries", "Processes the D Libraries"
                 val projectLibraryModel = projectLibraryTable.modifiableModel
 
                 //val uniqueLibName = LibraryEditingUtil.suggestNewLibraryName(projectLibraryModel, libraryName) // not needed as we remove clashes
-                val library = projectLibraryModel.createLibrary(libraryName, DlangLibraryType.DLANG_LIBRARY) // todo: use the ProjectModelExternalSource arg
+
+                var library = projectLibraryModel.getLibraryByName(libraryName)
+                if (library != null)
+                    projectLibraryModel.removeLibrary(library);
+                library = projectLibraryModel.createLibrary(libraryName, DlangLibraryType.DLANG_LIBRARY) // todo: use the ProjectModelExternalSource arg
 
                 val libraryModel = library.modifiableModel
 

--- a/src/main/java/io/github/intellij/dlanguage/codeinsight/DCompletionProvider.java
+++ b/src/main/java/io/github/intellij/dlanguage/codeinsight/DCompletionProvider.java
@@ -32,6 +32,7 @@ final class DCompletionProvider extends CompletionProvider<CompletionParameters>
     @Override
     protected void addCompletions(@NotNull CompletionParameters parameters, @NotNull ProcessingContext context, @NotNull CompletionResultSet result) {
         final PsiFile file = parameters.getOriginalFile();
+        final String fileText = file.getText();
 
         final CompletableFuture<List<Completion>> completionsFuture = CompletableFuture.runAsync(() -> {
             final Module module = ModuleUtilCore.findModuleForPsiElement(file);
@@ -48,7 +49,7 @@ final class DCompletionProvider extends CompletionProvider<CompletionParameters>
                 .runReadAction((Computable<Integer>) () -> parameters.getEditor().getCaretModel().getOffset());
 
             try {
-                return DCDCompletionClient.autoComplete(position, file, file.getText());
+                return DCDCompletionClient.autoComplete(position, file, fileText);
             } catch (DCDCompletionClient.DCDError e) {
                 log.warn(String.format("There was a problem using dcd-client on file %s at position %s",
                     file.getVirtualFile().getName(),

--- a/src/main/java/io/github/intellij/dlanguage/parser/DLangParser.java
+++ b/src/main/java/io/github/intellij/dlanguage/parser/DLangParser.java
@@ -4084,21 +4084,21 @@ class DLangParser {
      * Parses a ForeachType
      * <p>
      * $(GRAMMAR $(RULEDEF foreachType):
-     * ($(LITERAL 'ref') | $(LITERAL 'alias') | $(LITERAL 'enum') | $(RULE typeConstructor))* $(RULE type)? $(LITERAL Identifier)
+     * ($(LITERAL 'scope') | $(LITERAL 'ref') | $(LITERAL 'alias') | $(LITERAL 'enum') | $(RULE typeConstructor))* $(RULE type)? $(LITERAL Identifier)
      * ;)
      */
     boolean parseForeachType() {
         final Marker m = enter_section_modified(builder);
         while (moreTokens()) {
-            if (currentIs(tok("ref"))) {
+            if (currentIs(tok("scope"))) {
                 advance();
-            }
-            else if (currentIs(tok("alias"))) {
+            } else if (currentIs(tok("ref"))) {
+                advance();
+            } else if (currentIs(tok("alias"))) {
                 advance();
             } else if (currentIs(tok("enum"))) {
                 advance();
-            }
-            else if (!tok("").equals(parseTypeConstructor(false))) {
+            } else if (!tok("").equals(parseTypeConstructor(false))) {
                 //trace ("\033[01;36mType constructor");
             } else {
                 break;


### PR DESCRIPTION
Also included a fix to prevent a severe warning in the log:

```
addEntity: symbolic id already exists. Replacing entity with the new one.
Symbolic id: LibraryId(name=sidero_image:colorimetry-~master, tableId=com.intellij.workspaceModel.storage.bridgeEntities.LibraryTableId$ProjectLibraryTableId@5f6e1199)

Existing entity data: LibraryEntityData(name=sidero_image:colorimetry-~master, tableId=com.intellij.workspaceModel.storage.bridgeEntities.LibraryTableId$ProjectLibraryTableId@5f6e1199, roots=[LibraryRoot(url=file://P:/ProjectSidero/image/colorimetry, type=LibraryRootTypeId(name=CLASSES), inclusionOptions=ROOT_ITSELF)], entitySource=FileInDirectory(directory=file://P:/ProjectSidero/image/.idea/libraries, fileNameId=10, projectLocation=DirectoryBased(projectDir=file://P:/ProjectSidero/image, ideaFolder=file://P:/ProjectSidero/image/.idea)), id=0, id=0)
New entity data:      LibraryEntityData(name=sidero_image:colorimetry-~master, tableId=com.intellij.workspaceModel.storage.bridgeEntities.LibraryTableId$ProjectLibraryTableId@5f6e1199,
roots=[], entitySource=FileInDirectory(directory=file://P:/ProjectSidero/image/.idea/libraries, fileNameId=12, projectLocation=DirectoryBased(projectDir=file://P:/ProjectSidero/image, ideaFolder=file://P:/ProjectSidero/image/.idea)), id=-1, id=-1)

Broken consistency: false

com.intellij.workspaceModel.storage.impl.exceptions.SymbolicIdAlreadyExistsException: Entity with symbolicId: LibraryId(name=sidero_image:colorimetry-~master, tableId=com.intellij.workspaceModel.storage.bridgeEntities.LibraryTableId$ProjectLibraryTableId@5f6e1199) already exist
	at com.intellij.workspaceModel.storage.impl.MutableEntityStorageImpl.assertUniqueSymbolicId(EntityStorageSnapshotImpl.kt:227)
	at com.intellij.workspaceModel.storage.impl.MutableEntityStorageImpl.putEntity(EntityStorageSnapshotImpl.kt:194)
	at com.intellij.workspaceModel.storage.impl.ModifiableWorkspaceEntityBase.addToBuilder(Entities.kt:461)
	at com.intellij.workspaceModel.storage.bridgeEntities.LibraryEntityImpl$Builder.applyToBuilder(LibraryEntityImpl.kt:104)
	at com.intellij.workspaceModel.storage.impl.MutableEntityStorageImpl.addEntity(EntityStorageSnapshotImpl.kt:176)
	at com.intellij.workspaceModel.storage.bridgeEntities.ExtensionsKt.addLibraryEntityWithExcludes(extensions.kt:137)
	at com.intellij.workspaceModel.storage.bridgeEntities.ExtensionsKt.addLibraryEntity(extensions.kt:132)
	at com.intellij.workspaceModel.ide.impl.legacyBridge.library.ProjectModifiableLibraryTableBridgeImpl.createLibrary(ProjectModifiableLibraryTableBridgeImpl.kt:61)
	at com.intellij.workspaceModel.ide.impl.legacyBridge.library.ProjectModifiableLibraryTableBridgeImpl.createLibrary(ProjectModifiableLibraryTableBridgeImpl.kt:49)
	at io.github.intellij.dub.actions.ProcessDLibs$Companion.createLibraryDependency(ProcessDLibs.kt:207)
	at io.github.intellij.dub.actions.ProcessDLibs$Companion.processDLibsImpl(ProcessDLibs.kt:144)
	at io.github.intellij.dub.actions.ProcessDLibs$Companion.access$processDLibsImpl(ProcessDLibs.kt:75)
	at io.github.intellij.dub.actions.ProcessDLibs$Companion$processDLibs$2$task$1.run(ProcessDLibs.kt:105)
	at com.intellij.openapi.progress.impl.CoreProgressManager.startTask(CoreProgressManager.java:425)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.startTask(ProgressManagerImpl.java:114)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressAsynchronously$6(CoreProgressManager.java:476)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$3(ProgressRunner.java:252)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:190)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$13(CoreProgressManager.java:591)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:666)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:622)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:590)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:177)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:252)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:702)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:699)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:699)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

I know it should be split up, I'm kinda just annoyed at these errors that will hopefully resolve most of my day-to-day ones.