### PR TITLE
Don’t catch ProcessCancelledException to log them

### DIFF
--- a/dub/src/main/kotlin/io/github/intellij/dub/highlighting/annotation/DubSyntaxAnnotator.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/highlighting/annotation/DubSyntaxAnnotator.kt
@@ -28,14 +28,10 @@ class DubSyntaxAnnotator : ExternalAnnotator<PsiFile, DubSyntaxAnnotator.State>(
         val application = ApplicationManager.getApplication()
 
         if (fileDocumentManager.unsavedDocuments.isNotEmpty()) {
-            try {
-                application.invokeAndWait(
-                    { fileDocumentManager.saveAllDocuments() },
-                    application.defaultModalityState
-                )
-            } catch (e: ProcessCanceledException) {
-                LOG.warn("problem saving files", e)
-            }
+            application.invokeAndWait(
+                { fileDocumentManager.saveAllDocuments() },
+                application.defaultModalityState
+            )
         }
 
         return State(

--- a/src/main/java/io/github/intellij/dlanguage/highlighting/annotation/external/DExternalAnnotator.java
+++ b/src/main/java/io/github/intellij/dlanguage/highlighting/annotation/external/DExternalAnnotator.java
@@ -53,14 +53,10 @@ public class DExternalAnnotator extends ExternalAnnotator<PsiFile, DExternalAnno
         final Application application = ApplicationManager.getApplication();
 
         if (fileDocumentManager.getUnsavedDocuments().length > 0) {
-            try {
-                application.invokeAndWait(
-                    fileDocumentManager::saveAllDocuments,
-                    application.getDefaultModalityState()
-                );
-            } catch (final ProcessCanceledException e) {
-                LOG.warn("problem saving files", e);
-            }
+            application.invokeAndWait(
+                fileDocumentManager::saveAllDocuments,
+                application.getDefaultModalityState()
+            );
         }
 
         return new State(


### PR DESCRIPTION
It’s explicitelly said in doc, if some is catch it must be re-thrown and it should not be logged. If the action was cancelled, the action was cancelled. Don’t panic about it.