### PR TITLE
Almost completely rewrite DFormatAction to improve performance and fix Unicode mangling

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/actions/DFormatAction.java
+++ b/src/main/java/io/github/intellij/dlanguage/actions/DFormatAction.java
@@ -1,40 +1,42 @@
 package io.github.intellij.dlanguage.actions;
 
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.ExecutionHelper;
+import com.intellij.execution.ExecutionModes;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.CapturingProcessAdapter;
-import com.intellij.execution.process.OSProcessHandler;
-import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.*;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
-import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
-import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.ExceptionUtil;
+import io.github.intellij.dlanguage.codeinsight.dcd.DCDCompletionServer;
 import io.github.intellij.dlanguage.psi.DlangFile;
 import io.github.intellij.dlanguage.settings.ToolKey;
 import io.github.intellij.dlanguage.utils.DToolsNotificationAction;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Paths;
-import java.util.List;
 
 
 /**
  * Action that calls Dfmt on the buffer it is invoked for.
  */
-public class DFormatAction extends AnAction implements DumbAware {
+public class DFormatAction extends DumbAwareAction {
     private static final String NOTIFICATION_GROUPID = "Dfmt Action";
     private static final String NOTIFICATION_TITLE = "Reformat code with DFormat";
     private static final Logger LOG = Logger.getInstance(DFormatAction.class);
@@ -50,124 +52,116 @@ public class DFormatAction extends AnAction implements DumbAware {
         }
     }
 
-    /**
-     * Main entry point. Calls Dfmt
-     */
     @Override
-    public void actionPerformed(final AnActionEvent e) {
-        final PsiFile psiFile = e.getData(CommonDataKeys.PSI_FILE);
-        final Project project = getEventProject(e);
-        if (project == null) return;
-        if (!(psiFile instanceof DlangFile)) return;
-        final VirtualFile virtualFile = psiFile.getVirtualFile();
-        if (virtualFile == null) return;
+    public void actionPerformed(final AnActionEvent event) {
+        final PsiFile psiFile = event.getData(CommonDataKeys.PSI_FILE);
+        final VirtualFile virtualFile = event.getRequiredData(CommonDataKeys.VIRTUAL_FILE);
+        final Project project = getEventProject(event);
 
-        ApplicationManager.getApplication().invokeLaterOnWriteThread(() -> {
-            //final String groupId = e.getPresentation().getText();
-            try {
-                final GeneralCommandLine commandLine = new GeneralCommandLine();
-                final String dfmtPath = ToolKey.DFORMAT_KEY.getPath();
-                final String dfmtFlags = ToolKey.DFORMAT_KEY.getFlags();
-                if (dfmtPath == null || dfmtPath.isEmpty()) {
+        if (project == null || !(psiFile instanceof DlangFile))
+            return;
 
-                    showNotification(NOTIFICATION_TITLE,
-                        "DFormat executable path is empty",
-                        NotificationType.WARNING,
-                        new DToolsNotificationAction("Configure"),
-                        project);
-                    return;
-                }
+        // if we tell the editor to save the file, we can avoid reading in its contents and all the thread stuff that goes with it.
+        Document document = FileDocumentManager.getInstance().getDocument(virtualFile);
+        if (document == null)
+            return;
+        FileDocumentManager.getInstance().saveDocument(document);
 
-                if (!Paths.get(dfmtPath).toFile().canExecute()) {
-                    showNotification(NOTIFICATION_TITLE,
-                        "DFormat executable path is not valid",
-                        NotificationType.WARNING,
-                        new DToolsNotificationAction("Configure"),
-                        project);
+        // This will execute dfmt on another background thread that shouldn't throw up BGT too slow errors
+        // and the best part? It'll give us a progress indicator!
+        ProgressManager.getInstance().run(new Task.Backgroundable(project, "DFormat formatting: " + ((DlangFile) psiFile).getFullyQualifiedModuleName()) {
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                final GeneralCommandLine commandLine = createCommandLine(project, virtualFile);
 
-                    return;
-                }
+                try {
+                    // This particular process handle is quite brilliant.
+                    // It allows the user to kill dfmt gracefully, and if that fails forcefully.
+                    final ProcessHandler processHandler = new KillableProcessHandler(commandLine);
 
-                commandLine.setExePath(dfmtPath);
-                commandLine.getParametersList().addParametersString(dfmtFlags);
+                    // we need process output from dfmt to have an idea of if it was succesfull and if not notify the user of stderr.
+                    final ProcessOutput processOutput = new ProcessOutput();
+                    processHandler.addProcessListener(new CapturingProcessAdapter(processOutput) {
+                        // when dfmt completes (for whatever reason), we'll learn of its error code and grab its stderr output
+                        @Override
+                        public void processTerminated(@NotNull ProcessEvent event) {
+                            super.processTerminated(event);
 
-                final VirtualFile backingFile = psiFile.getVirtualFile();
-                if (backingFile == null) return;
-                final String backingFilePath = backingFile.getCanonicalPath();
-                if (backingFilePath == null) return;
-                commandLine.addParameter(backingFilePath);
-                // Set the work dir so dfmt can pick up the user config, if it exists.
-                commandLine.setWorkDirectory(backingFile.getParent().getCanonicalPath());
+                            // first lets check to see if dfmt executed correctly
+                            final boolean success = event.getExitCode() == 0 && processOutput.getStderr().isEmpty();
 
-                ApplicationManager.getApplication().saveAll();
-
-                final String commandLineString = commandLine.getCommandLineString();
-                final OSProcessHandler handler = new OSProcessHandler(commandLine.createProcess(), commandLineString);
-                handler.addProcessListener(new CapturingProcessAdapter() {
-                    @Override
-                    public void processTerminated(@NotNull final ProcessEvent event) {
-                        @NotNull final List<String> errors = getOutput().getStderrLines();
-
-                        if (!errors.isEmpty()) {
-                            final String[] parts = errors.get(0).split("\\[\\w+]:\\s");
-                            final String output = parts.length == 2 ? parts[1] : errors.get(0);
-                            showNotification("DFormat error.", output, NotificationType.ERROR, null, project);
-                            return;
-                        }
-
-                        final String text = getOutput().getStdout();
-                        ApplicationManager.getApplication().invokeLater(() -> {
-                            try {
-                                @Nullable final Document document = PsiDocumentManager.getInstance(project).getDocument(psiFile);
-                                if (document == null) {
-                                    return;
-                                }
-                                CommandProcessor.getInstance()
-                                    .executeCommand(
-                                        project,
-                                        () -> ApplicationManager
-                                            .getApplication()
-                                            .runWriteAction(() -> document.setText(text)),
-                                        NOTIFICATION_TITLE,
-                                        "",
-                                        document
-                                    );
-
-                                showNotification(NOTIFICATION_TITLE,
-                                    psiFile.getName() + " formatted with DFormat.",
-                                    NotificationType.INFORMATION, null, project);
-
-                            } catch (final Exception e) {
-                                showNotification("Formatting " + psiFile.getName() + "  with DFormat failed.",
-                                    ExceptionUtil.getUserStackTrace(e, LOG),
-                                    NotificationType.ERROR, null, project);
-
-                                //LOG.error(e);
+                            if (!success) {
+                                // this is the most interesting condition
+                                // we need to log stderr
+                                notifyOfError("Formatting " + psiFile.getName() + "  with DFormat failed.", processOutput.getStderr(), project);
+                                return;
                             }
-                        });
-                    }
-                });
-                handler.startNotify();
-            } catch (final Exception ex) {
-                showNotification("Formatting " + psiFile.getName() + " with DFormat failed",
-                    ExceptionUtil.getUserStackTrace(ex, LOG),
-                    NotificationType.ERROR, null, project);
 
-                LOG.error(ex);
+                            notifyOfInformation(psiFile.getName() + " formatted with DFormat.", project);
+                        }
+                    });
+
+                    processHandler.startNotify();
+
+                    final ExecutionModes.SameThreadMode sameThreadMode = new ExecutionModes.SameThreadMode("DFormat " + virtualFile.getCanonicalPath());
+                    ExecutionHelper.executeExternalProcess(project, processHandler, sameThreadMode, commandLine);
+                } catch (ExecutionException e) {
+                    notifyOfError("Formatting " + psiFile.getName() + " with DFormat failed", ExceptionUtil.getUserStackTrace(e, LOG), project);
+                    LOG.error(e);
+                    return;
+                }
+
+                // this is expected to reload the editor automatically
+                VfsUtil.markDirtyAndRefresh(true, true, true, virtualFile);
             }
         });
     }
 
-    private void showNotification(@NotNull final String title,
-                                  @NotNull final String content,
-                                  @NotNull final NotificationType type,
-                                  @Nullable final AnAction action,
-                                  @Nullable final Project project) {
-        final Notification notification = new Notification(NOTIFICATION_GROUPID, title, content, type);
+    GeneralCommandLine createCommandLine(@NotNull Project project, @NotNull VirtualFile virtualFile) {
+        final String dfmtPath = ToolKey.DFORMAT_KEY.getPath();
+        final String dfmtFlags = ToolKey.DFORMAT_KEY.getFlags();
 
-        if (action != null)
-            notification.addAction(action);
+        if (dfmtPath == null || dfmtPath.isEmpty()) {
+            notifyOfWarning("DFormat executable path is empty", project);
+            return null;
+        }
 
+        if (!Paths.get(dfmtPath).toFile().canExecute()) {
+            notifyOfWarning("DFormat executable path is not valid", project);
+            return null;
+        }
+
+        final GeneralCommandLine commandLine = new GeneralCommandLine();
+        commandLine.setExePath(dfmtPath);
+        commandLine.getParametersList().addParametersString(dfmtFlags);
+
+        if (!(dfmtFlags.contains("-i") || dfmtFlags.contains("--inplace"))) {
+            // Do the work in place of the file system, rather than handle it with stdio (which could be slow)
+            commandLine.addParameter("--inplace");
+        }
+
+        commandLine.getParametersList().addParametersString(virtualFile.getCanonicalPath());
+
+        // Given the directory that the file that we are formatting is in
+        //  set the current working directory of the processing being executed to it
+        // This will allow .editorconfig to be searched for and be found in relation to the file.
+        commandLine.setWorkDirectory(virtualFile.getParent().getCanonicalPath());
+        return commandLine;
+    }
+
+    private void notifyOfInformation(@NotNull String errorMessage, @NotNull Project project) {
+        final Notification notification = new Notification(NOTIFICATION_GROUPID, NOTIFICATION_TITLE, errorMessage, NotificationType.INFORMATION);
+        Notifications.Bus.notify(notification, project);
+    }
+
+    private void notifyOfWarning(@NotNull String errorMessage, @NotNull Project project) {
+        final Notification notification = new Notification(NOTIFICATION_GROUPID, NOTIFICATION_TITLE, errorMessage, NotificationType.WARNING);
+        notification.addAction(new DToolsNotificationAction("Configure"));
+        Notifications.Bus.notify(notification, project);
+    }
+
+    private void notifyOfError(@NotNull String title, @NotNull String errorMessage, @NotNull Project project) {
+        final Notification notification = new Notification(NOTIFICATION_GROUPID, title, errorMessage, NotificationType.ERROR);
         Notifications.Bus.notify(notification, project);
     }
 }


### PR DESCRIPTION
This rewrite of DFormatAction was brought on because I was getting 8-second+ freezes of IntelliJ.

It also happens to fix the mangling of Unicode characters in comments.

The code was inspired by a Go plugin and I've now used it for over 2 hours the only error I've gotten was by an Android plugin that for whatever reason is loaded with the dev IDE.

May close: https://github.com/intellij-dlanguage/intellij-dlanguage/issues/765