### PR TITLE
Some intellij plugin inspection fixes

### DIFF
--- a/debugger/src/main/java/uk/co/cwspencer/gdb/gdbmi/GdbMiParser2.java
+++ b/debugger/src/main/java/uk/co/cwspencer/gdb/gdbmi/GdbMiParser2.java
@@ -814,7 +814,7 @@ public class GdbMiParser2 {
             return subRes;
         }
 
-        Integer matchGroup = 0;
+        int matchGroup = 0;
 
         // number="1"
         GdbMiResult numVal = new GdbMiResult("number");
@@ -925,7 +925,7 @@ public class GdbMiParser2 {
             return subRes;
         }
 
-        Integer matchGroup = 0;
+        int matchGroup = 0;
 
         // number="1"
         GdbMiResult numVal = new GdbMiResult("number");

--- a/debugger/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbValue.java
+++ b/debugger/src/main/java/uk/co/cwspencer/ideagdb/debug/GdbValue.java
@@ -71,7 +71,7 @@ public class GdbValue extends XValue {
     @Override
     public void computePresentation(@NotNull final XValueNode node, @NotNull XValuePlace place) {
         final String goType = GdbUtil.getGoObjectType(m_variableObject.type);
-        final Boolean hasChildren = m_variableObject.numChildren != null && m_variableObject.numChildren > 0;
+        final boolean hasChildren = m_variableObject.numChildren != null && m_variableObject.numChildren > 0;
 
         if (goType.equals("string")) {
             handleGoString(node);
@@ -163,7 +163,7 @@ public class GdbValue extends XValue {
 
     private void onGoGdbStringReady(@NotNull final XValueNode node, GdbEvent event) {
         String value;
-        Boolean isTrueString = false;
+        boolean isTrueString = false;
         if (event instanceof GdbErrorEvent) {
             value = ((GdbErrorEvent) event).message;
         } else if (!(event instanceof GdbVariableObjects)) {
@@ -196,7 +196,7 @@ public class GdbValue extends XValue {
 
             node.setPresentation(getGdbVarIcon(), "string (" + value.length() + ")", value, false);
         } else {
-            Boolean hasChildren = m_variableObject.numChildren != null && m_variableObject.numChildren > 0;
+            boolean hasChildren = m_variableObject.numChildren != null && m_variableObject.numChildren > 0;
             node.setPresentation(getGdbVarIcon(), "unknown", m_variableObject.value, hasChildren);
         }
     }

--- a/dub/src/main/kotlin/io/github/intellij/dub/actions/ConfigureDToolsAction.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/actions/ConfigureDToolsAction.kt
@@ -1,6 +1,7 @@
 package io.github.intellij.dub.actions
 
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.options.ShowSettingsUtil
@@ -27,4 +28,7 @@ class ConfigureDToolsAction : DubAction("Configure D Tools", null, AllIcons.Gene
         }
     }
 
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.EDT;
+    }
 }

--- a/dub/src/main/kotlin/io/github/intellij/dub/actions/DubBuildAction.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/actions/DubBuildAction.kt
@@ -6,6 +6,7 @@ import com.intellij.execution.impl.RunManagerImpl
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.ModuleManager
@@ -60,5 +61,9 @@ class DubBuildAction : DubAction("_Run Dub", "", AllIcons.Actions.Execute) {
             dubBuildRunner.execute(env)
         }
 
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/dub/src/main/kotlin/io/github/intellij/dub/actions/ProcessDLibs.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/actions/ProcessDLibs.kt
@@ -8,6 +8,7 @@ import com.intellij.execution.process.ProcessEvent
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
@@ -70,6 +71,10 @@ class ProcessDLibs : AnAction("Process D Libraries", "Processes the D Libraries"
     */
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabled = canRunDub(e)
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.EDT;
     }
 
     companion object {

--- a/dub/src/main/kotlin/io/github/intellij/dub/project/DubListenerComponent.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/project/DubListenerComponent.kt
@@ -2,6 +2,7 @@ package io.github.intellij.dub.project
 
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.startup.StartupActivity
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.impl.BulkVirtualFileListenerAdapter
@@ -10,8 +11,8 @@ import io.github.intellij.dub.project.DubConfigFileListener.Companion.getDubFile
 /**
  * Created by francis on 1/27/2018.
  */
-class DubListenerComponent : StartupActivity {
-    override fun runActivity(project: Project) {
+class DubListenerComponent : ProjectActivity {
+    override suspend fun execute(project: Project) {
         for (module in ModuleManager.getInstance(project).modules) {
             val dubFile = getDubFileFromModule(module!!)
             if (dubFile != null) {

--- a/dub/src/main/kotlin/io/github/intellij/dub/toolwindow/DubToolWindowPanel.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/toolwindow/DubToolWindowPanel.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.packageDependencies.ui.PackageDependenciesNode
 import com.intellij.ui.ColoredTreeCellRenderer
+import com.intellij.ui.JBColor
 import com.intellij.ui.ScrollPaneFactory
 import com.intellij.ui.SimpleTextAttributes
 import com.intellij.ui.treeStructure.Tree
@@ -247,7 +248,7 @@ class DubToolWindowPanel(val project: Project, val toolWindow: ToolWindow) :
                         append("${dependency.name} ${dependency.version}",
                                 SimpleTextAttributes(
                                     SimpleTextAttributes.STYLE_ITALIC,
-                                    Color.GRAY
+                                    JBColor.GRAY
                                 )
                         )
                     }

--- a/dub/src/main/kotlin/io/github/intellij/dub/toolwindow/DubToolWindowPanel.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/toolwindow/DubToolWindowPanel.kt
@@ -366,6 +366,10 @@ class DubToolWindowPanel(val project: Project, val toolWindow: ToolWindow) :
         override fun setSelected(e: AnActionEvent, state: Boolean) {
             // todo
         }
+
+        override fun getActionUpdateThread(): ActionUpdateThread {
+            return ActionUpdateThread.BGT;
+        }
     }
 
 }

--- a/src/main/java/io/github/intellij/dlanguage/actions/DFormatAction.java
+++ b/src/main/java/io/github/intellij/dlanguage/actions/DFormatAction.java
@@ -8,6 +8,7 @@ import com.intellij.execution.process.*;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
@@ -147,6 +148,11 @@ public class DFormatAction extends DumbAwareAction {
         // This will allow .editorconfig to be searched for and be found in relation to the file.
         commandLine.setWorkDirectory(virtualFile.getParent().getCanonicalPath());
         return commandLine;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     private void notifyOfInformation(@NotNull String errorMessage, @NotNull Project project) {

--- a/src/main/java/io/github/intellij/dlanguage/actions/RestartDCD.java
+++ b/src/main/java/io/github/intellij/dlanguage/actions/RestartDCD.java
@@ -3,6 +3,7 @@ package io.github.intellij.dlanguage.actions;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
@@ -55,6 +56,11 @@ public class RestartDCD extends AnAction implements DumbAware { // todo: conside
         if (size == 0) displayError(e, prefix + "No DLanguage modules are used in this project.");
         else if (size == 1) restartDcdServer(e, modules.iterator().next());
         else showModuleChoicePopup(e, project, modules);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     private static void showModuleChoicePopup(@NotNull final AnActionEvent e, final Project project, final Collection<Module> modules) {

--- a/src/main/java/io/github/intellij/dlanguage/utils/DToolsNotificationAction.java
+++ b/src/main/java/io/github/intellij/dlanguage/utils/DToolsNotificationAction.java
@@ -1,5 +1,6 @@
 package io.github.intellij.dlanguage.utils;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.options.ShowSettingsUtil;
@@ -22,4 +23,8 @@ public class DToolsNotificationAction extends AnAction implements DumbAware {
         ShowSettingsUtil.getInstance().showSettingsDialog(e.getProject(), DLanguageToolsConfigurable.D_TOOLS_ID);
     }
 
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
+    }
 }

--- a/src/main/kotlin/io/github/intellij/dlanguage/project/creation.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/project/creation.kt
@@ -21,6 +21,7 @@ import com.intellij.platform.DirectoryProjectGenerator
 import com.intellij.platform.DirectoryProjectGeneratorBase
 import com.intellij.platform.GeneratorPeerImpl
 import com.intellij.platform.ProjectGeneratorPeer
+import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBPanel
 import com.intellij.util.ui.components.BorderLayoutPanel
 import io.github.intellij.dlanguage.DLanguage
@@ -72,7 +73,7 @@ class DlangProjectGenerator : DirectoryProjectGeneratorBase<DlangProjectSettings
 
         dmdPanel.border = BorderFactory.createCompoundBorder(
             BorderFactory.createTitledBorder(
-                BorderFactory.createLineBorder(Color.LIGHT_GRAY, 1, true),
+                BorderFactory.createLineBorder(JBColor.LIGHT_GRAY, 1, true),
                 "D compiler"
             ),
             BorderFactory.createEmptyBorder(10, 0, 20, 0)

--- a/src/main/kotlin/io/github/intellij/dlanguage/template/DlangContext.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/template/DlangContext.kt
@@ -6,8 +6,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiUtilCore
 import io.github.intellij.dlanguage.DLanguage
 
-open class DlangContext protected constructor() : TemplateContextType("D", "D Language") {
-
+open class DlangContext protected constructor() : TemplateContextType("D Language") {
     override fun isInContext(context: TemplateActionContext): Boolean {
         return PsiUtilCore.getLanguageAtOffset(context.file, context.startOffset).isKindOf(DLanguage)
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -192,7 +192,7 @@
         <!-- Live Templates -->
         <defaultLiveTemplates file="/dlang/ide/liveTemplates/D"/>
 
-        <liveTemplateContext implementation="io.github.intellij.dlanguage.template.DlangContext"/>
+        <liveTemplateContext implementation="io.github.intellij.dlanguage.template.DlangContext" contextId="D"/>
         <!--<liveTemplateContext implementation="io.github.intellij.dlanguage.template.DlangContextType$Statement"/>-->
         <!--<liveTemplateContext implementation="io.github.intellij.dlanguage.template.DlangContextType$Item"/>-->
         <!--<liveTemplateContext implementation="io.github.intellij.dlanguage.template.DlangContextType$Struct"/>-->


### PR DESCRIPTION
A bunch of commits that were originated from Intellij's code inspection facilities.

Unfortunately, nothing was raised regarding nullability as was talked about in another ticket.

Of note is the getActionUpdateThread methods, turns out those exceptions aren't just there because the actions were running on BGT, it seems they were really running on EDT this entire time. By moving them to BGT the IDE is now really responsive, which I was very shocked about! Looks like my un-comfortability the last few days about this has been justified.

Oh, and I've talked with WebFreak about Dscanner and the full-line-length warnings we get. Yesterday they worked on custom formats and a few other things that could improve our support. However, they recommended that we switch to the report form (JSON) instead of using regex to get at the data. So at some point, we should rewrite the dscanner implementation.

![Capture](https://github.com/intellij-dlanguage/intellij-dlanguage/assets/992755/c544d441-8f13-43d5-bc94-a1c267afdaa7)