### PR TITLE
Attempted fix for issue #880

### DIFF
--- a/dub/src/main/kotlin/io/github/intellij/dub/project/DubConfigurationParser.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/project/DubConfigurationParser.kt
@@ -254,7 +254,7 @@ class DubConfigurationParser @JvmOverloads constructor(
                 val message = String.format("%s exited with %s:\n%s", dubCommand, exitCode, errors[0])
                 LOG.warn(message)
                 if (!silentMode) {
-                    SwingUtilities.invokeLater { Messages.showErrorDialog(project, message, "Dub Import") }
+                    ApplicationManager.getApplication().invokeLater({ Messages.showErrorDialog(project, message, "Dub Import") })
                 }
             }
         } catch (e: com.intellij.execution.ExecutionException) {


### PR DESCRIPTION
I believe this will fix it.

The problem is it's running in the context of a read action, the invokeLater call should put it on to the EDT using a write action.

From ModalityState which configures this behavior:

> For these reasons, it's strongly advised to use Application.invokeLater methods everywhere instead of SwingUtilities.invokeLater(Runnable) and com.intellij.util.ui.UIUtil convenience methods.