### PR TITLE
Fix wrong test

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/psi/references/DReference.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/psi/references/DReference.kt
@@ -51,7 +51,13 @@ class DReference(element: PsiNamedElement, textRange: TextRange) : PsiReferenceB
 
 
         val project = myElement.project
-        val namedElements = DResolveUtil.getInstance(project).findDefinitionNode(myElement, false).map { if (it is PsiNameIdentifierOwner && it !is ModuleDeclaration && it !is SingleImport) if (it.nameIdentifier != null) it.nameIdentifier!! else it else it }
+        val namedElements = DResolveUtil.getInstance(project).findDefinitionNode(myElement, false).map {
+            if (it is PsiNameIdentifierOwner && it !is ModuleDeclaration && it !is SingleImport && it !is Constructor)
+                if (it.nameIdentifier != null)
+                    it.nameIdentifier!!
+                else it
+            else it
+        }
         val results = mutableListOf<PsiElementResolveResult>()
         for (property in namedElements) {
             results.add(PsiElementResolveResult(property))

--- a/src/main/kotlin/io/github/intellij/dlanguage/resolve/DResolveUtil.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/resolve/DResolveUtil.kt
@@ -52,14 +52,14 @@ class DResolveUtil private constructor(val project: Project) {
             return SpecialCaseResolve.findDefinitionNode(e)
         }
 
-        var basicResolveResult = BasicResolve.getInstance(project, profile).findDefinitionNode(e)
-        if(resolvingConstructor(e) == null){
-            basicResolveResult = basicResolveResult.filter { it !is Constructor }.toSet()
-        } else {
-            val constructorsOnly = basicResolveResult.filter { it is Constructor }.toSet()
-            if (constructorsOnly.isNotEmpty())
-                return constructorsOnly
+        if (resolvingConstructor(e) != null) {
+            val basicResolveResult = BasicResolve.getInstance(project, profile).findDefinitionNode(e)
+            return basicResolveResult.filter { it is Constructor }.toSet()
         }
+
+        var basicResolveResult = BasicResolve.getInstance(project, profile).findDefinitionNode(e)
+        basicResolveResult = basicResolveResult.filter { it !is Constructor }.toSet()
+
         if (basicResolveResult.isEmpty())
             return SpecialCaseResolve.tryPackageResolve(e)
         return basicResolveResult

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
@@ -53,7 +53,11 @@ abstract class DResolveTestCase : DLightPlatformCodeInsightFixtureTestCase("reso
     }
 
     private fun findResolvedInFile(psiFile: PsiElement, resolvedOffset: Int) {
-        val ref = psiFile.findReferenceAt(resolvedOffset)
+        var element = psiFile.findElementAt(resolvedOffset)
+        while (element!!.reference == null || element.reference is DlangIdentifier) {
+            element = element.parent
+        }
+        val ref = element.reference
         if (ref == null) {
             fail("Reference was null in " + psiFile.containingFile.name)
         }


### PR DESCRIPTION
I discovered while doing some change in the resolve, that a test was wrong but was passing.
The class construction was resolved to the class definition even if a constructor was defined. But due to a wrong reference searching in setup step of tests, the reference found was the same as the wrong one find in the setup.