### PR TITLE
Improve links in console when building

### DIFF
--- a/dub/src/main/kotlin/io/github/intellij/dub/run/DubBuildStackTraceFilter.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/run/DubBuildStackTraceFilter.kt
@@ -1,13 +1,10 @@
 package io.github.intellij.dub.run
 
 import com.intellij.execution.filters.*
-import com.intellij.openapi.editor.markup.EffectType
-import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import java.awt.Color
-import java.awt.Font
-import java.lang.NumberFormatException
+import kotlin.NumberFormatException
 
 class DubConsoleFilterProvider : ConsoleFilterProvider {
     override fun getDefaultFilters(project: Project): Array<Filter> = arrayOf(DubBuildSourceFileFilter(project))
@@ -26,13 +23,13 @@ class DubBuildSourceFileFilter(val project: Project) : Filter {
         //     source\package\app.di(53,31): Some Log output
         //     source\package\app.di Some Log output
         //     source\path\app.d:21 Some text output
-        val D_SOURCE_PATH_FORMAT = Regex("^(.*\\.di?):?(\\(\\d+,\\d+\\)|\\d+)?:?\\s+(.*)\$")
+        val D_SOURCE_PATH_FORMAT = Regex("""^(.*\.di?):?(\(\d+,\d+\)|\d+)?:?\s+(.*\n?)$""")
 
         private val BLUE = Color(39, 89, 230)
     }
 
     override fun applyFilter(line: String, entireLength: Int): Filter.Result? {
-        if((line.startsWith("source") || line.startsWith("src")) && line.matches(D_SOURCE_PATH_FORMAT)) {
+        if(line.matches(D_SOURCE_PATH_FORMAT)) {
             // then it's fairly certain we can get a hyperlink to the source file and possibly the line number
             val groups = line.lineSequence()
                 .flatMap { D_SOURCE_PATH_FORMAT.find(it)?.groupValues ?: emptyList() }
@@ -44,12 +41,13 @@ class DubBuildSourceFileFilter(val project: Project) : Filter {
                 .findFileByPath(project.basePath.plus("/").plus(groups[0].replace("\\", "/")))
 
             // negate 1 from the line number as IDEA does line numbers starting from
-            val lineNumber = if(groups[1].isNotBlank()) groups[1].parseLineNumber() -1 else 0
+            val lineNumber = if(groups[1].isNotBlank()) groups[1].parseLineNumber() - 1 else 0
+            val columnNumber = if(groups[1].isNotBlank()) groups[1].parseColumnNumber() - 1 else 0
 
+            val offset = entireLength - line.length
             file?.let {
-                return Filter.Result(0, groups[0].length,
-                    OpenFileHyperlinkInfo(project, it, lineNumber),
-                    TextAttributes(BLUE, null, null, EffectType.BOLD_LINE_UNDERSCORE, Font.ITALIC)
+                return Filter.Result(offset, offset + groups[0].length,
+                    OpenFileHyperlinkInfo(project, it, lineNumber, columnNumber),
                 )
             }
         }
@@ -62,7 +60,7 @@ private fun String.parseLineNumber(): Int {
         this.substringAfter("(")
             .substringBefore(")")
             .split(",").
-            first() // when the test is "(23:25)" it's line number followed by column. We don't need the column
+            first() // when the test is "(23,25)" it's line number followed by column. We don't need the column
     else
         this
 
@@ -73,3 +71,17 @@ private fun String.parseLineNumber(): Int {
     }
 }
 
+private fun String.parseColumnNumber(): Int {
+    val number = if (this.startsWith("("))
+        this.substringAfter("(")
+            .substringBefore(")")
+            .split(",")[1] // when the test is "(23,25)" it's line number followed by column. We need the column
+    else
+        return 0
+
+    return try {
+        Integer.parseInt(number)
+    } catch (e: NumberFormatException) {
+        0 // zeros is fin as default line number
+    }
+}

--- a/dub/src/test/kotlin/io/github/intellij/dub/run/DubBuildSourceFileFilterTest.kt
+++ b/dub/src/test/kotlin/io/github/intellij/dub/run/DubBuildSourceFileFilterTest.kt
@@ -6,6 +6,16 @@ import junit.framework.TestCase
 class DubBuildSourceFileFilterTest : LightPlatformTestCase() {
 
     @Throws(Exception::class)
+    fun `test line match correctly matching`() {
+        TestCase.assertTrue("source\\package\\app.d Some Log output".matches(DubBuildSourceFileFilter.D_SOURCE_PATH_FORMAT))
+        // Windows separators
+        TestCase.assertTrue("source\\package\\app.d Some Log output\n".matches(DubBuildSourceFileFilter.D_SOURCE_PATH_FORMAT))
+        // Unix separators
+        TestCase.assertTrue("source/package/app.d Some Log output\n".matches(DubBuildSourceFileFilter.D_SOURCE_PATH_FORMAT))
+
+    }
+
+    @Throws(Exception::class)
     fun `test the regex for splitting a D source path, line no, and message`() {
         TestCase.assertEquals("source\\package\\app.d",
             DubBuildSourceFileFilter.D_SOURCE_PATH_FORMAT.find("source\\package\\app.d Some Log output")!!.groupValues[1]
@@ -66,13 +76,16 @@ class DubBuildSourceFileFilterTest : LightPlatformTestCase() {
 
         val filter = DubBuildSourceFileFilter(project)
 
-        val result = filter.applyFilter(line, line.length)
-
-        TestCase.assertNull(result) // WILL BE NULL DUE TO STATIC METHODS IN CODE BASE
-        //TestCase.assertNotNull(result)
-        //val resultItem = result?.resultItems?.get(0)!!
-        //TestCase.assertEquals(0, resultItem.getHighlightStartOffset())
-        //TestCase.assertEquals(31, resultItem.getHighlightEndOffset())
+        assertNoThrowable{filter.applyFilter(line, line.length)}
+        TestCase.assertEquals("source\\config\\database.d",
+            DubBuildSourceFileFilter.D_SOURCE_PATH_FORMAT.find(line)!!.groupValues[1]
+        )
+        TestCase.assertEquals("(53,31)",
+            DubBuildSourceFileFilter.D_SOURCE_PATH_FORMAT.find(line)!!.groupValues[2]
+        )
+        TestCase.assertEquals("blah blah blah, some other stuff",
+            DubBuildSourceFileFilter.D_SOURCE_PATH_FORMAT.find(line)!!.groupValues[3]
+        )
     }
 
     @Throws(Exception::class)
@@ -81,13 +94,16 @@ class DubBuildSourceFileFilterTest : LightPlatformTestCase() {
 
         val filter = DubBuildSourceFileFilter(project)
 
-        val result = filter.applyFilter(line, line.length)
-
-        TestCase.assertNull(result) // WILL BE NULL DUE TO STATIC METHODS IN CODE BASE
-        //TestCase.assertNotNull(result)
-        //val resultItem = result?.resultItems?.get(0)!!
-        //TestCase.assertEquals(0, resultItem.getHighlightStartOffset())
-        //TestCase.assertEquals(31, resultItem.getHighlightEndOffset())
+        assertNoThrowable{filter.applyFilter(line, line.length)}
+        TestCase.assertEquals("source/app.d",
+            DubBuildSourceFileFilter.D_SOURCE_PATH_FORMAT.find(line)!!.groupValues[1]
+        )
+        TestCase.assertEquals("21",
+            DubBuildSourceFileFilter.D_SOURCE_PATH_FORMAT.find(line)!!.groupValues[2]
+        )
+        TestCase.assertEquals("_D3std9exception__T7bailOutHTC9ExceptionZQwFNaNfAyamMAxaZNn [0x10c0aa25a]",
+            DubBuildSourceFileFilter.D_SOURCE_PATH_FORMAT.find(line)!!.groupValues[3]
+        )
     }
 
     @Throws(Exception::class)

--- a/src/main/kotlin/io/github/intellij/dlanguage/run/DmdConsoleFilterProvider.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/run/DmdConsoleFilterProvider.kt
@@ -1,0 +1,36 @@
+package io.github.intellij.dlanguage.run
+
+import com.intellij.execution.filters.ConsoleFilterProviderEx
+import com.intellij.execution.filters.Filter
+import com.intellij.execution.filters.OpenFileHyperlinkInfo
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.search.GlobalSearchScope
+
+class DmdConsoleFilterProvider : ConsoleFilterProviderEx {
+
+    override fun getDefaultFilters(project: Project): Array<Filter> {
+        return  getDefaultFilters(project, GlobalSearchScope.allScope(project))
+    }
+
+    override fun getDefaultFilters(project: Project, scope: GlobalSearchScope): Array<Filter> {
+        return arrayOf(DmdConsoleFilter(project, scope))
+    }
+}
+
+class DmdConsoleFilter(val project: Project, val scope: GlobalSearchScope) : Filter {
+    override fun applyFilter(line: String, entireLength: Int): Filter.Result? {
+        val messageSuffix = pattern.find(line) ?: return null
+        val pathEnd = messageSuffix.groups[1]!!.range.last + 1
+        val path = line.substring(0, pathEnd)
+        val lineNumber = Integer.parseInt(messageSuffix.groupValues[2]) - 1
+
+        val offset = entireLength - line.length
+        val file = LocalFileSystem.getInstance().findFileByPathIfCached(path)?: return null
+        return Filter.Result(offset, offset + messageSuffix.range.last, OpenFileHyperlinkInfo(project, file, lineNumber, 0))
+    }
+
+    companion object {
+        val pattern = Regex("""(\.di?)\((\d+)\):""")
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -120,6 +120,8 @@
         <configurationType implementation="io.github.intellij.dlanguage.run.DlangRunDmdConfigurationType"/>
         <programRunner implementation="io.github.intellij.dlanguage.run.DmdBuildRunner"/>
 
+        <consoleFilterProvider implementation="io.github.intellij.dlanguage.run.DmdConsoleFilterProvider"/>
+
         <configurationType implementation="io.github.intellij.dlanguage.run.DlangRunAppConfigurationType"/>
 
 

--- a/src/test/kotlin/io/github/intellij/dlanguage/run/DmdBuildStackTraceFilterTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/run/DmdBuildStackTraceFilterTest.kt
@@ -1,0 +1,25 @@
+package io.github.intellij.dlanguage.run
+
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.testFramework.LightPlatformTestCase
+import junit.framework.TestCase
+
+class DmdBuildStackTraceFilterTest : LightPlatformTestCase() {
+    @Throws(Exception::class)
+    fun `test line match correctly matching`() {
+        TestCase.assertNotNull(DmdConsoleFilter.pattern.find("/home/user/project/source/main.d(135): Error: declaration `main.main.x` is already defined"))
+        TestCase.assertNotNull(DmdConsoleFilter.pattern.find("/home/user/project/source/main.d(130):        `variable` `x` is defined here"))
+    }
+
+    fun `test find correct elements`() {
+        val found = DmdConsoleFilter.pattern.find("/home/user/project/source/main.d(135): Error: declaration `main.main.x` is already defined")!!
+        TestCase.assertEquals(3, found.groups.size)
+        TestCase.assertEquals("/home/user/project/source/main.d".length, found.groups[1]!!.range.last + 1)
+        TestCase.assertEquals("135", found.groupValues[2])
+    }
+
+    fun `test apply filter`() {
+        val line = "/home/user/project/source/main.d(135): Error: declaration `main.main.x` is already defined"
+        assertNoThrowable{DmdConsoleFilter(project, GlobalSearchScope.allScope(project)).applyFilter(line, line.length)}
+    }
+}


### PR DESCRIPTION
- Fix the stack trace filter for dub (file was not detected due to ending \n + link was missplassed in console due to wrong offset calculation)
- Add new stack trace filter for dmd bulid

I manually checked that file path were highlighted and pointing to the good location