### PR TITLE
Fix error when building plugin

### DIFF
--- a/dub/src/main/kotlin/io/github/intellij/dub/run/DubBuildStackTraceFilter.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/run/DubBuildStackTraceFilter.kt
@@ -29,11 +29,11 @@ class DubBuildSourceFileFilter(val project: Project) : Filter {
     }
 
     override fun applyFilter(line: String, entireLength: Int): Filter.Result? {
-        if(line.matches(D_SOURCE_PATH_FORMAT)) {
-            // then it's fairly certain we can get a hyperlink to the source file and possibly the line number
-            val groups = line.lineSequence()
-                .flatMap { D_SOURCE_PATH_FORMAT.find(it)?.groupValues ?: emptyList() }
-                .drop(1) // the first one will be entire string
+        val found = line.lineSequence()
+            .flatMap { D_SOURCE_PATH_FORMAT.find(it)?.groupValues ?: emptyList() }
+        if (found.toList().isNotEmpty()) {
+            // then it's certain we can get a hyperlink to the source file and possibly the line number
+            val groups = found.drop(1) // the first one will be entire string
                 .toList()
 
             val file = LocalFileSystem

--- a/dub/src/test/kotlin/io/github/intellij/dub/run/DubBuildSourceFileFilterTest.kt
+++ b/dub/src/test/kotlin/io/github/intellij/dub/run/DubBuildSourceFileFilterTest.kt
@@ -116,4 +116,15 @@ class DubBuildSourceFileFilterTest : LightPlatformTestCase() {
 
         TestCase.assertNull("shouldn't apply filter if no source found", result)
     }
+
+    @Throws(Exception::class)
+    fun `test filtering dub output with som file path inside`() {
+        val line = "Starting process 'command 'rdmd''. Working directory: /path/to/intellij/intellij-dlanguage/gen/io/github/intellij/dlanguage/psi Command: rdmd types_regen_script.d\n"
+
+        val filter = DubBuildSourceFileFilter(project)
+
+        val result = filter.applyFilter(line, line.length)
+
+        TestCase.assertNull("shouldn't apply filter if no source found", result)
+    }
 }


### PR DESCRIPTION
At step to run rdmd, the first check was passing but then no match was found, this led to an unhandled exception. Change the logic to be more robust.