### PR TITLE
Fix wrong resolution for named enum values

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/resolve/ScopeProcessorImplUtil.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/resolve/ScopeProcessorImplUtil.kt
@@ -47,7 +47,7 @@ object ScopeProcessorImplUtil {
 
         }
         if (def.enumDeclaration != null) {
-            if (def.enumDeclaration?.enumBody?.enumMembers != null) {
+            if (def.enumDeclaration!!.identifier == null && def.enumDeclaration!!.enumBody?.enumMembers != null) {
                 for (enumMember in def.enumDeclaration!!.enumBody!!.enumMembers) {
                     if (!processor.execute(enumMember, state)) {
                         toContinue = false

--- a/src/main/kotlin/io/github/intellij/dlanguage/stubs/index/StubIndexUtil.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/stubs/index/StubIndexUtil.kt
@@ -2,9 +2,11 @@ package io.github.intellij.dlanguage.stubs.index
 
 import com.intellij.psi.stubs.NamedStubBase
 import com.intellij.psi.stubs.StubElement
+import io.github.intellij.dlanguage.psi.DLanguageAnonymousEnumDeclaration
 import io.github.intellij.dlanguage.psi.interfaces.DNamedElement
 import io.github.intellij.dlanguage.stubs.*
 import io.github.intellij.dlanguage.stubs.interfaces.DlangUnittestStub
+import io.github.intellij.dlanguage.utils.EnumMember
 
 /**
  * Created by francis on 8/8/2017.
@@ -16,6 +18,10 @@ fun <S : NamedStubBase<T>, T : DNamedElement> topLevelDeclaration(stub: S): Bool
 
     if (stub is DlangParameterStub || stub is DlangForeachTypeStub || stub is DlangTemplateParameterStub) {
         return false
+    }
+
+    if (stub is DlangEnumMemberStub) {
+        return stub.parentStub !is DlangEnumDeclarationStub
     }
 
 

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
@@ -80,4 +80,15 @@ class DResolveTest : DResolveTestCase() {
 
     @Test
     fun testConstructorCallResolveParameters() = doTest()
+
+    @Test
+    fun testAnonymousEnumUsage() = doTest()
+
+    // TODO should work but resolve state is not currently powerful enough to handle this case
+    //      it needs to handle the chain resolve (A.B)
+    //@Test
+    //fun testEnumUsageWithEnumTypePrefix() = doTest()
+
+    @Test
+    fun testEnumUsageWithoutEnumTypePrefixShouldNotResolve() = doTest(false)
 }

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
@@ -55,7 +55,7 @@ abstract class DResolveTestCase : DLightPlatformCodeInsightFixtureTestCase("reso
             }
             val psiFile = myFixture.configureByText(file.name, text)
             if (referencedOffset != -1) {
-                referencedElement = psiFile.findReferenceAt(referencedOffset)
+                referencedElement = psiFile.findElementAt(referencedOffset)!!.parent.reference!!
             }
             if (resolvedOffset != -1) {
                 findResolvedInFile(psiFile, resolvedOffset)
@@ -122,7 +122,11 @@ abstract class DResolveTestCase : DLightPlatformCodeInsightFixtureTestCase("reso
                 assertEquals("Could not resolve expected reference.", resolvedElement, element!!.parent)
             }
         } else {
-            assertFalse("Resolved unexpected reference.", resolvedElement == referencedElement!!.resolve())
+            if (resolvedElement == null) {
+                assertNull("The reference should not resolve to anything but a reference was found", referencedElement!!.resolve())
+            } else {
+                assertFalse("Resolved unexpected reference.", resolvedElement == referencedElement!!.resolve())
+            }
         }
     }
 

--- a/src/test/resources/gold/resolve/anonymousEnumUsage/usage.d
+++ b/src/test/resources/gold/resolve/anonymousEnumUsage/usage.d
@@ -1,0 +1,10 @@
+module usage;
+
+enum {
+    A,
+    <resolved>X,
+}
+
+void main() {
+    auto a = E.<ref>X;
+}

--- a/src/test/resources/gold/resolve/enumUsageWithEnumTypePrefix/usage.d
+++ b/src/test/resources/gold/resolve/enumUsageWithEnumTypePrefix/usage.d
@@ -1,0 +1,10 @@
+module usage;
+
+enum E {
+    A,
+    <resolved>X,
+}
+
+void main() {
+    auto a = E.<ref>X;
+}

--- a/src/test/resources/gold/resolve/enumUsageWithoutEnumTypePrefixShouldNotResolve/usage.d
+++ b/src/test/resources/gold/resolve/enumUsageWithoutEnumTypePrefixShouldNotResolve/usage.d
@@ -1,0 +1,10 @@
+module usage;
+
+enum E {
+    A,
+    X,
+}
+
+void main() {
+    foo(<ref>X);
+}


### PR DESCRIPTION
Only anonymous enums can be accessed directly.

This unfortunately breaks the resolve of the enum values accessed correctly. This will require more work to support chained calls.

But at least, the enum members won’t be resolved when they should not.