### PR TITLE
Fix issue #905, #790 and duplicative modules when loading via dub

### DIFF
--- a/dub/src/main/kotlin/io/github/intellij/dub/project/DubProjectOpenProcessor.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/project/DubProjectOpenProcessor.kt
@@ -6,6 +6,7 @@ import com.intellij.ide.util.projectWizard.WizardContext
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ex.ProjectManagerEx
 import com.intellij.openapi.roots.ProjectRootManager
@@ -77,6 +78,13 @@ class DubProjectOpenProcessor : ProjectOpenProcessorBase<DubProjectImportBuilder
         if (project != null) {
             // Run on EDT for with the ability to take a write action lock
             ApplicationManager.getApplication().invokeLater {
+                var mm = ModuleManager.getInstance(project)
+                mm.modules.forEach{
+                    // I couldn't figure out where project was gaining the additional module(s)
+                    // so we'll just dispose it and it'll be fine and things should work ok without it
+                    mm.disposeModule(it)
+                }
+
                 val sdk = DlangSdkType.findOrCreateSdk()
                 val builder = DlangModuleBuilder(sdk)
 

--- a/src/main/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionClient.java
+++ b/src/main/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionClient.java
@@ -10,6 +10,7 @@ import com.intellij.execution.process.ProcessOutputType;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.ProjectUtil;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -72,9 +73,11 @@ public final class DCDCompletionClient {
         }
 
         final GeneralCommandLine dcdClientCommand = buildDcdCommand(dcdPath, position, file);
+        // Protect reading the file's text with the read lock
+        final String fileText = ApplicationManager.getApplication().runReadAction((Computable<String>) () -> file.getText());
 
         try {
-            return runCommandLine(dcdClientCommand, file.getText()).get(2L, TimeUnit.SECONDS);
+            return runCommandLine(dcdClientCommand, fileText).get(2L, TimeUnit.SECONDS);
         } catch (InterruptedException | java.util.concurrent.ExecutionException | TimeoutException e) {
             throw new DCDError(e);
         }


### PR DESCRIPTION
I also noticed that ``visitDeclaratorIdentifierList`` was missing when I built it, I stubbed it out locally but that isn't right.

It does concern me that we are doing more work than required and I have to later on remove modules when loading via dub.
I couldn't work out what introduced it, but anyway now it has the source directory set without the dialog from the exception.