### PR TITLE
Remove usages of DFile where DPsiFile is enough

### DIFF
--- a/dub/src/main/kotlin/io/github/intellij/dub/run/DlangRunDubConfigurationProducer.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/run/DlangRunDubConfigurationProducer.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import io.github.intellij.dlanguage.DlangWritingAccessProvider
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 import io.github.intellij.dlanguage.utils.DUtil
 
 class DlangRunDubConfigurationProducer : LazyRunConfigurationProducer<DlangRunDubConfiguration>() {
@@ -20,7 +20,7 @@ class DlangRunDubConfigurationProducer : LazyRunConfigurationProducer<DlangRunDu
         val psiLocation = context.psiLocation
         val psiFile = psiLocation?.containingFile
         val virtualFile = getRealVirtualFile(psiFile)
-        return if (psiFile is DlangFile && virtualFile != null &&
+        return if (psiFile is DlangPsiFile && virtualFile != null &&
             ProjectRootManager.getInstance(context.project).fileIndex.isInContent(virtualFile) &&
             !DlangWritingAccessProvider.isInDLanguageSdkOrDLanguagePackagesFolder(psiFile.getProject(), virtualFile)
         ) {
@@ -39,7 +39,7 @@ class DlangRunDubConfigurationProducer : LazyRunConfigurationProducer<DlangRunDu
         val psiLocation = context.psiLocation
         val psiFile = psiLocation?.containingFile
         val virtualFile = getRealVirtualFile(psiFile)
-        return if (psiFile is DlangFile && virtualFile != null) virtualFile else null
+        return if (psiFile is DlangPsiFile && virtualFile != null) virtualFile else null
     }
 
     private fun getRealVirtualFile(psiFile: PsiFile?): VirtualFile? {

--- a/src/main/java/io/github/intellij/dlanguage/actions/DFormatAction.java
+++ b/src/main/java/io/github/intellij/dlanguage/actions/DFormatAction.java
@@ -11,7 +11,6 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -20,13 +19,11 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.ExceptionUtil;
-import io.github.intellij.dlanguage.codeinsight.dcd.DCDCompletionServer;
-import io.github.intellij.dlanguage.psi.DlangFile;
+import io.github.intellij.dlanguage.psi.DlangPsiFile;
 import io.github.intellij.dlanguage.settings.ToolKey;
 import io.github.intellij.dlanguage.utils.DToolsNotificationAction;
 import org.jetbrains.annotations.NotNull;
@@ -49,7 +46,7 @@ public class DFormatAction extends DumbAwareAction {
     public void update(final AnActionEvent e) {
         final PsiFile psiFile = e.getData(CommonDataKeys.PSI_FILE);
         if (psiFile != null) {
-            e.getPresentation().setEnabled(DlangFile.class.isAssignableFrom(psiFile.getClass()));
+            e.getPresentation().setEnabled(DlangPsiFile.class.isAssignableFrom(psiFile.getClass()));
         }
     }
 
@@ -59,7 +56,7 @@ public class DFormatAction extends DumbAwareAction {
         final VirtualFile virtualFile = event.getRequiredData(CommonDataKeys.VIRTUAL_FILE);
         final Project project = getEventProject(event);
 
-        if (project == null || !(psiFile instanceof DlangFile))
+        if (project == null || !(psiFile instanceof DlangPsiFile))
             return;
 
         if (!virtualFile.isValid()) {
@@ -75,7 +72,7 @@ public class DFormatAction extends DumbAwareAction {
 
         // This will execute dfmt on another background thread that shouldn't throw up BGT too slow errors
         // and the best part? It'll give us a progress indicator!
-        ProgressManager.getInstance().run(new Task.Backgroundable(project, "DFormat formatting: " + ((DlangFile) psiFile).getFullyQualifiedModuleName()) {
+        ProgressManager.getInstance().run(new Task.Backgroundable(project, "DFormat formatting: " + ((DlangPsiFile) psiFile).getFullyQualifiedModuleName()) {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
                 final GeneralCommandLine commandLine = createCommandLine(project, virtualFile);

--- a/src/main/java/io/github/intellij/dlanguage/psi/impl/DElementFactory.java
+++ b/src/main/java/io/github/intellij/dlanguage/psi/impl/DElementFactory.java
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileFactory;
 import io.github.intellij.dlanguage.DLanguage;
 import io.github.intellij.dlanguage.psi.DLanguageAliasDeclaration;
-import io.github.intellij.dlanguage.psi.DlangFile;
+import io.github.intellij.dlanguage.psi.DlangPsiFile;
 import io.github.intellij.dlanguage.psi.named.DlangModuleDeclaration;
 import io.github.intellij.dlanguage.psi.named.DlangIdentifier;
 import org.jetbrains.annotations.NotNull;
@@ -42,7 +42,7 @@ public class DElementFactory {
      */
     @Nullable
     private static PsiElement createExpressionFromText(@NotNull final Project project, @NotNull final String name) {
-        @NotNull final DlangFile fileFromText = createFileFromText(project, name);
+        @NotNull final DlangPsiFile fileFromText = createFileFromText(project, name);
 
         @Nullable final PsiElement firstChild = fileFromText.getFirstChild();
 
@@ -59,9 +59,9 @@ public class DElementFactory {
      * Create a file containing text.
      */
     @NotNull
-    private static DlangFile createFileFromText(@NotNull final Project project,
+    private static DlangPsiFile createFileFromText(@NotNull final Project project,
                                                 @NotNull final String text) {
-        return (DlangFile) PsiFileFactory.getInstance(project)
+        return (DlangPsiFile) PsiFileFactory.getInstance(project)
             .createFileFromText("A.hs", DLanguage.INSTANCE, text);
     }
 

--- a/src/main/java/io/github/intellij/dlanguage/psi/interfaces/HasMembers.java
+++ b/src/main/java/io/github/intellij/dlanguage/psi/interfaces/HasMembers.java
@@ -7,10 +7,8 @@ import com.intellij.psi.stubs.NamedStubBase;
 import com.intellij.psi.stubs.Stub;
 import com.intellij.psi.stubs.StubElement;
 import io.github.intellij.dlanguage.stubs.*;
-import io.github.intellij.dlanguage.psi.DlangFile;
 import io.github.intellij.dlanguage.psi.DLanguageSharedStaticConstructor;
 import io.github.intellij.dlanguage.psi.DLanguageSharedStaticDestructor;
-import io.github.intellij.dlanguage.stubs.*;
 import io.github.intellij.dlanguage.stubs.interfaces.DlangUnittestStub;
 
 import java.util.Collections;
@@ -24,9 +22,8 @@ import org.jetbrains.annotations.NotNull;
 public interface HasMembers<T extends StubElement> extends StubBasedPsiElement<T>, DNamedElement {
     default Set<NamedStubBase> getMembers() {
         final Set<NamedStubBase> res = new HashSet<>();
-        ((DlangFile) getContainingFile()).calcStubTree();
 
-        final StubElement greenStub = ((StubBasedPsiElementBase) this).getGreenStub();
+        final StubElement greenStub = ((StubBasedPsiElementBase<T>) this).getGreenStub();
         if (greenStub == null) {
             Logger.getInstance(this.getClass())
                 .warn("Green stub was null for file:" + getContainingFile());

--- a/src/main/java/io/github/intellij/dlanguage/stubs/DlangFileStub.java
+++ b/src/main/java/io/github/intellij/dlanguage/stubs/DlangFileStub.java
@@ -1,13 +1,13 @@
 package io.github.intellij.dlanguage.stubs;
 
 import com.intellij.psi.stubs.PsiFileStubImpl;
-import io.github.intellij.dlanguage.psi.DlangFile;
+import io.github.intellij.dlanguage.psi.DlangPsiFileImpl;
 
 /**
  * Basic implementation of a stub for a D file so we can index its contents.
  */
-public class DlangFileStub extends PsiFileStubImpl<DlangFile> {
-    public DlangFileStub(final DlangFile file) {
+public class DlangFileStub extends PsiFileStubImpl<DlangPsiFileImpl> {
+    public DlangFileStub(final DlangPsiFileImpl file) {
         super(file);
     }
 }

--- a/src/main/java/io/github/intellij/dlanguage/stubs/types/DFileStubElementType.java
+++ b/src/main/java/io/github/intellij/dlanguage/stubs/types/DFileStubElementType.java
@@ -8,10 +8,7 @@ import com.intellij.psi.stubs.StubInputStream;
 import com.intellij.psi.stubs.StubOutputStream;
 import com.intellij.psi.tree.IStubFileElementType;
 import io.github.intellij.dlanguage.DLanguage;
-import io.github.intellij.dlanguage.psi.DlangFile;
-import io.github.intellij.dlanguage.stubs.DlangFileStub;
-import io.github.intellij.dlanguage.DLanguage;
-import io.github.intellij.dlanguage.psi.DlangFile;
+import io.github.intellij.dlanguage.psi.DlangPsiFileImpl;
 import io.github.intellij.dlanguage.stubs.DlangFileStub;
 import org.jetbrains.annotations.NotNull;
 
@@ -31,8 +28,8 @@ public class DFileStubElementType extends IStubFileElementType<DlangFileStub> {
             @NotNull
             @Override
             protected StubElement createStubForFile(@NotNull final PsiFile file) {
-                if (file instanceof DlangFile) {
-                    return new DlangFileStub((DlangFile) file);
+                if (file instanceof DlangPsiFileImpl) {
+                    return new DlangFileStub((DlangPsiFileImpl) file);
                 }
                 return super.createStubForFile(file);
             }

--- a/src/main/java/io/github/intellij/dlanguage/unittest/DUnitTestFramework.java
+++ b/src/main/java/io/github/intellij/dlanguage/unittest/DUnitTestFramework.java
@@ -4,8 +4,8 @@ import com.intellij.ide.fileTemplates.FileTemplateDescriptor;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
+import io.github.intellij.dlanguage.DLanguage;
 import io.github.intellij.dlanguage.psi.DLanguageAtAttribute;
-import io.github.intellij.dlanguage.psi.DlangFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -68,7 +68,7 @@ public class DUnitTestFramework extends DlangTestFramework {
     public boolean isTestMethod(final PsiElement element) {
         // TODO: However you determine whether a method is a test method.  For example, in mine they’re annotated with @Test or the testMethod modifier
 
-        if (element.getClass() == DlangFile.class) {
+        if (element.getLanguage() == DLanguage.INSTANCE) {
             final Collection<DLanguageAtAttribute> udas = PsiTreeUtil.findChildrenOfType(element, DLanguageAtAttribute.class);
             return !udas.isEmpty();
         } else {

--- a/src/main/java/io/github/intellij/dlanguage/unittest/DUnitTestRunConfigurationProducer.java
+++ b/src/main/java/io/github/intellij/dlanguage/unittest/DUnitTestRunConfigurationProducer.java
@@ -9,7 +9,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import io.github.intellij.dlanguage.DlangWritingAccessProvider;
-import io.github.intellij.dlanguage.psi.DlangFile;
+import io.github.intellij.dlanguage.psi.DlangPsiFile;
 import io.github.intellij.dlanguage.utils.DUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,7 +44,7 @@ public class DUnitTestRunConfigurationProducer extends LazyRunConfigurationProdu
         final PsiFile psiFile = psiLocation == null ? null : psiLocation.getContainingFile();
         final VirtualFile virtualFile = getRealVirtualFile(psiFile);
 
-        if ((psiFile instanceof DlangFile) &&
+        if ((psiFile instanceof DlangPsiFile) &&
                 virtualFile != null &&
                 ProjectRootManager.getInstance(context.getProject()).getFileIndex().isInContent(virtualFile) &&
                 !DlangWritingAccessProvider.isInDLanguageSdkOrDLanguagePackagesFolder(psiFile.getProject(), virtualFile)) {
@@ -72,7 +72,7 @@ public class DUnitTestRunConfigurationProducer extends LazyRunConfigurationProdu
         @Nullable final PsiElement psiLocation = context.getPsiLocation();
         final PsiFile psiFile = psiLocation == null ? null : psiLocation.getContainingFile();
         final VirtualFile virtualFile = getRealVirtualFile(psiFile);
-        return psiFile instanceof DlangFile && virtualFile != null ? virtualFile : null;
+        return psiFile instanceof DlangPsiFile && virtualFile != null ? virtualFile : null;
     }
 
     public static VirtualFile getRealVirtualFile(final PsiFile psiFile) {

--- a/src/main/kotlin/io/github/intellij/dlanguage/DLanguage.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/DLanguage.kt
@@ -29,7 +29,7 @@ import com.intellij.ui.EditorNotificationPanel
 import io.github.intellij.dlanguage.index.DModuleIndex
 import io.github.intellij.dlanguage.parser.ParserWrapper
 import io.github.intellij.dlanguage.psi.DTokenSets.STRING_LITERALS
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFileImpl
 import io.github.intellij.dlanguage.psi.DlangTypes
 import io.github.intellij.dlanguage.resolve.processors.basic.BasicResolve
 import io.github.intellij.dlanguage.stubs.types.DFileStubElementType
@@ -225,7 +225,7 @@ class DLangParserDefinition : ParserDefinition {
     @NotNull
     override fun createParser(project: Project?): ParserWrapper = ParserWrapper()
 
-    override fun createFile(viewProvider: FileViewProvider): PsiFile = DlangFile(viewProvider)
+    override fun createFile(viewProvider: FileViewProvider): PsiFile = DlangPsiFileImpl(viewProvider)
 
     override fun spaceExistenceTypeBetweenTokens(left: ASTNode?, right: ASTNode?): ParserDefinition.SpaceRequirements = ParserDefinition.SpaceRequirements.MAY
 

--- a/src/main/kotlin/io/github/intellij/dlanguage/features/DDocumentationProvider.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/features/DDocumentationProvider.kt
@@ -6,7 +6,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import io.github.intellij.dlanguage.features.documentation.DDocGenerator
 import io.github.intellij.dlanguage.features.documentation.DSignatureDocGenerator
 import io.github.intellij.dlanguage.features.documentation.psi.DlangDocComment
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 import io.github.intellij.dlanguage.psi.impl.named.DlangSingleImportImpl
 import io.github.intellij.dlanguage.psi.interfaces.DNamedElement
 import io.github.intellij.dlanguage.psi.named.DlangSingleImport
@@ -55,7 +55,7 @@ class DDocumentationProvider : AbstractDocumentationProvider() {
     }
 
     override fun collectDocComments(file: PsiFile, sink: Consumer<in PsiDocCommentBase>) {
-        if (file !is DlangFile) return
+        if (file !is DlangPsiFile) return
         for (element in SyntaxTraverser.psiTraverser(file)) {
             if (element is DlangDocComment) {
                 sink.accept(element)

--- a/src/main/kotlin/io/github/intellij/dlanguage/features/documentation/DDocParserDefinition.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/features/documentation/DDocParserDefinition.kt
@@ -31,7 +31,7 @@ import io.github.intellij.dlanguage.features.documentation.DDocElementTypes.DDOC
 import io.github.intellij.dlanguage.features.documentation.DDocElementTypes.DDOC_THROWS_SECTION
 import io.github.intellij.dlanguage.features.documentation.DDocElementTypes.DDOC_VERSION_SECTION
 import io.github.intellij.dlanguage.features.documentation.psi.impl.*
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFileImpl
 
 class DDocParserDefinition : ParserDefinition {
     override fun createLexer(project: Project?): Lexer = DDocLexer()
@@ -72,6 +72,6 @@ class DDocParserDefinition : ParserDefinition {
         }
     }
 
-    override fun createFile(viewProvider: FileViewProvider): PsiFile = DlangFile(viewProvider) // TODO can actually be DDocFile (.dd)
+    override fun createFile(viewProvider: FileViewProvider): PsiFile = DlangPsiFileImpl(viewProvider) // TODO can actually be DDocFile (.dd)
 
 }

--- a/src/main/kotlin/io/github/intellij/dlanguage/features/formatter/DFormattingModelBuilder.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/features/formatter/DFormattingModelBuilder.kt
@@ -203,7 +203,7 @@ class DFormattingModelBuilder : FormattingModelBuilder {
                 return element is DlangModuleDeclaration
                     || element is io.github.intellij.dlanguage.psi.DLanguageImportDeclaration
                     || element is DLanguageDeclaration
-                    || element is DLanguageStatement && element.getParent() is io.github.intellij.dlanguage.psi.DlangFile
+                    || element is DLanguageStatement && element.getParent() is io.github.intellij.dlanguage.psi.DlangPsiFile
             }
 
             private fun lineBreak(keepLineBreaks: Boolean = true): Spacing {

--- a/src/main/kotlin/io/github/intellij/dlanguage/folding/DFoldingBuilder.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/folding/DFoldingBuilder.kt
@@ -61,7 +61,7 @@ class DFoldingBuilder : FoldingBuilderEx(), DumbAware {
         }
 
     override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
-        if (root !is DlangFile)
+        if (root !is DlangPsiFile)
             return emptyArray()
 
         val descriptors: MutableList<FoldingDescriptor> = ArrayList()

--- a/src/main/kotlin/io/github/intellij/dlanguage/highlighting/exitpoint/DHighlightExitPointsHandlerFactory.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/highlighting/exitpoint/DHighlightExitPointsHandlerFactory.kt
@@ -6,13 +6,13 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiUtilCore
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 import io.github.intellij.dlanguage.psi.DlangTypes.KW_RETURN
 import io.github.intellij.dlanguage.psi.DlangTypes.KW_THROW
 
 class DHighlightExitPointsHandlerFactory : HighlightUsagesHandlerFactoryBase() {
     override fun createHighlightUsagesHandler(editor: Editor, file: PsiFile, target: PsiElement): HighlightUsagesHandlerBase<*>? {
-        if (file !is DlangFile) return null
+        if (file !is DlangPsiFile) return null
 
         val elementType = PsiUtilCore.getElementType(target)
         if (elementType == KW_RETURN || elementType == KW_THROW) {

--- a/src/main/kotlin/io/github/intellij/dlanguage/index/DModuleIndex.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/index/DModuleIndex.kt
@@ -10,7 +10,7 @@ import com.intellij.util.indexing.*
 import com.intellij.util.io.EnumeratorStringDescriptor
 import com.intellij.util.io.KeyDescriptor
 import io.github.intellij.dlanguage.DlangFileType
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 import java.util.*
 
 
@@ -34,7 +34,7 @@ class DModuleIndex : ScalarIndexExtension<String>() {
     private class MyDataIndexer : DataIndexer<String, Void, FileContent> {
         override fun map(inputData: FileContent): Map<String, Void?> {
             val psiFile = inputData.psiFile
-            if (psiFile is DlangFile) {
+            if (psiFile is DlangPsiFile) {
                 val moduleName = psiFile.getFullyQualifiedModuleName()
                 if (psiFile.name == "package.d") {
                     val directoryBasedModuleName = getDirectoryBasedModuleName(inputData)
@@ -78,14 +78,14 @@ class DModuleIndex : ScalarIndexExtension<String>() {
         @Deprecated("Only Logger and constant should be in the companion object!")
         fun getFilesByModuleName(project: Project,
                                  moduleName: String,
-                                 searchScope: GlobalSearchScope): List<DlangFile> {
+                                 searchScope: GlobalSearchScope): List<DlangPsiFile> {
             val psiManager = PsiManager.getInstance(project)
 
             val virtualFiles = FileBasedIndex.getInstance().getContainingFiles(D_MODULE_INDEX, moduleName, searchScope)
 
             return ContainerUtil.mapNotNull(virtualFiles) { virtualFile: VirtualFile? ->
                 val psiFile = psiManager.findFile(virtualFile!!)
-                if (psiFile is DlangFile) psiFile else null
+                if (psiFile is DlangPsiFile) psiFile else null
             }
         }
     }

--- a/src/main/kotlin/io/github/intellij/dlanguage/presentation/Utils.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/presentation/Utils.kt
@@ -69,7 +69,7 @@ fun getPresentationIcon(psi: PsiElement?): Icon? = when (psi) {
     is AliasDeclaration -> DLanguage.Icons.NODE_ALIAS
     is MixinTemplateDeclaration -> DLanguage.Icons.NODE_MIXIN
     is TemplateDeclaration -> getPresentationIcon(psi.parent)
-    is DlangFile -> DLanguage.Icons.FILE
+    is DlangPsiFile -> DLanguage.Icons.FILE
     else -> null
 }
 

--- a/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/projectview/DPsiFileNode.kt
@@ -6,16 +6,15 @@ import com.intellij.ide.projectView.impl.nodes.BasePsiNode
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
-import com.intellij.psi.PsiFile
 import com.intellij.ui.SimpleTextAttributes
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 
 /**
  * Each instance of this class corresponds to a D language file
  * in the project view.
  */
-class DPsiFileNode(project: Project?, dFilePsi: DlangFile, viewSettings: ViewSettings) :
-    BasePsiNode<DlangFile>(project, dFilePsi, viewSettings) {
+class DPsiFileNode(project: Project?, dFilePsi: DlangPsiFile, viewSettings: ViewSettings) :
+    BasePsiNode<DlangPsiFile>(project, dFilePsi, viewSettings) {
 
     override fun getTypeSortKey(): Comparable<*> = TypeSortKey(this)
 
@@ -26,12 +25,12 @@ class DPsiFileNode(project: Project?, dFilePsi: DlangFile, viewSettings: ViewSet
     override fun canRepresent(element: Any?): Boolean {
         if (super.canRepresent(element)) return true
 
-        val value: DlangFile? = value
+        val value: DlangPsiFile? = value
         return value != null && element != null && element == value.virtualFile
     }
 
     override fun updateImpl(data: PresentationData) {
-        val filePsi: DlangFile? = value
+        val filePsi: DlangPsiFile? = value
         if (filePsi != null) {
             data.presentableText = value.getModuleName()
             val fileName = filePsi.virtualFile.nameWithoutExtension

--- a/src/main/kotlin/io/github/intellij/dlanguage/projectview/ProjectViewUtil.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/projectview/ProjectViewUtil.kt
@@ -2,15 +2,15 @@ package io.github.intellij.dlanguage.projectview
 
 import com.intellij.ide.projectView.impl.nodes.PsiFileNode
 import com.intellij.psi.PsiManager
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 
 /**
- * Returns the [DlangFile] associated with this [PsiFileNode], or
+ * Returns the [DlangPsiFile] associated with this [PsiFileNode], or
  * `null` if at least one of the following is true for this node:
  *
  *  - Not part of a project.
  *  - Has no associated [VirtualFile][com.intellij.openapi.vfs.VirtualFile].
  *  - Not a D source file.
  */
-val PsiFileNode.dlangFile: DlangFile?
-    get() = this.project?.let { p -> virtualFile?.let { vf -> PsiManager.getInstance(p).findFile(vf) } } as? DlangFile
+val PsiFileNode.dlangFile: DlangPsiFile?
+    get() = this.project?.let { p -> virtualFile?.let { vf -> PsiManager.getInstance(p).findFile(vf) } } as? DlangPsiFile

--- a/src/main/kotlin/io/github/intellij/dlanguage/psi/DlangItemPresentation.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/psi/DlangItemPresentation.kt
@@ -11,7 +11,7 @@ import javax.swing.Icon
  */
 abstract class DlangItemPresentation protected constructor(private val psiFile: PsiFile) : ItemPresentation {
     override fun getLocationString(): String? {
-        return if (psiFile is DlangFile) psiFile.getModuleName() else null
+        return if (psiFile is DlangPsiFile) psiFile.getModuleName() else null
     }
 
     override fun getIcon(unused: Boolean): Icon {

--- a/src/main/kotlin/io/github/intellij/dlanguage/psi/DlangPsiFileImpl.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/psi/DlangPsiFileImpl.kt
@@ -22,7 +22,7 @@ import javax.swing.Icon
 
 // todo: consider making this class abstract so that there can be x2 classes that inherit from it.
 // One for .di files (interfaces) and another for regular .d source files
-class DlangFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, DLanguage), DlangPsiFile {
+class DlangPsiFileImpl(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, DLanguage), DlangPsiFile {
     override fun getFileType(): FileType = DlangFileType
 
     override fun toString(): String {

--- a/src/main/kotlin/io/github/intellij/dlanguage/psi/references/DReference.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/psi/references/DReference.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.IncorrectOperationException
 import io.github.intellij.dlanguage.processors.DCompletionProcessor
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 import io.github.intellij.dlanguage.psi.interfaces.DNamedElement
 import io.github.intellij.dlanguage.psi.named.DlangIdentifier
 import io.github.intellij.dlanguage.resolve.DResolveUtil
@@ -119,7 +119,7 @@ class DReference(element: PsiNamedElement, textRange: TextRange) : PsiReferenceB
     }
 
     private fun addSymbolsFromImports(project: Project, result: MutableList<String>) {
-        val decls = StubIndex.getElements(DTopLevelDeclarationsByModule.KEY, (element.containingFile as DlangFile).getFullyQualifiedModuleName(), project, GlobalSearchScope.fileScope(element.containingFile), DNamedElement::class.java)
+        val decls = StubIndex.getElements(DTopLevelDeclarationsByModule.KEY, (element.containingFile as DlangPsiFile).getFullyQualifiedModuleName(), project, GlobalSearchScope.fileScope(element.containingFile), DNamedElement::class.java)
         for (decl in decls) {
             if (decl is FunctionDeclaration) {
                 result.add(decl.name + "(" + ")")

--- a/src/main/kotlin/io/github/intellij/dlanguage/refactoring/rename/DlangRenameFileActionProvider.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/refactoring/rename/DlangRenameFileActionProvider.kt
@@ -2,7 +2,7 @@ package io.github.intellij.dlanguage.refactoring.rename
 
 import com.intellij.psi.PsiFile
 import com.intellij.refactoring.actions.RenameFileActionProvider
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 
 /**
  * @author Samael Bate (singingbush)
@@ -10,6 +10,6 @@ import io.github.intellij.dlanguage.psi.DlangFile
  */
 class DlangRenameFileActionProvider : RenameFileActionProvider {
     override fun enabledInProjectView(file: PsiFile): Boolean {
-        return DlangFile::class.java.isAssignableFrom(file.javaClass)
+        return file is DlangPsiFile
     }
 }

--- a/src/main/kotlin/io/github/intellij/dlanguage/resolve/processors/basic/BasicResolve.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/resolve/processors/basic/BasicResolve.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.search.GlobalSearchScope.allScope
 import com.intellij.psi.util.PsiTreeUtil
 import io.github.intellij.dlanguage.attributes.DNameScopeProcessor
 import io.github.intellij.dlanguage.index.DModuleIndex
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 import io.github.intellij.dlanguage.utils.Identifier
 
 
@@ -27,8 +27,8 @@ class BasicResolve private constructor(val project: Project, val profile: Boolea
         }
     }
 
-    val `object`: DlangFile?
-        get() = DModuleIndex.getFilesByModuleName(project, "object", allScope(project)).toSet().firstOrNull()?.containingFile as DlangFile?
+    val `object`: DlangPsiFile?
+        get() = DModuleIndex.getFilesByModuleName(project, "object", allScope(project)).toSet().firstOrNull()?.containingFile as DlangPsiFile?
 
     fun findDefinitionNode(e: PsiNamedElement): Set<PsiNamedElement> {
         //todo fix templated functions return type bug

--- a/src/main/kotlin/io/github/intellij/dlanguage/resolve/processors/parameters/DAttributesFinder.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/resolve/processors/parameters/DAttributesFinder.kt
@@ -272,7 +272,7 @@ class DAttributesFinder {
                 if (!execute(point)) {
                     return
                 }
-                if (point is DlangFile || point.prevSibling == null) {
+                if (point is DlangPsiFile || point.prevSibling == null) {
                     break
                 }
                 point = point.prevSibling
@@ -287,7 +287,7 @@ class DAttributesFinder {
     fun isParent(parent: PsiElement, child: PsiElement): Boolean {
         if (child == parent)
             return true
-        if (child is DlangFile) {
+        if (child is DlangPsiFile) {
             return false
         }
         return isParent(parent, child.parent)

--- a/src/main/kotlin/io/github/intellij/dlanguage/structure/DStructureViewFactory.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/structure/DStructureViewFactory.kt
@@ -6,14 +6,14 @@ import com.intellij.ide.structureView.TreeBasedStructureViewBuilder
 import com.intellij.lang.PsiStructureViewFactory
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiFile
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 
 class DStructureViewFactory : PsiStructureViewFactory {
     override fun getStructureViewBuilder(psiFile: PsiFile): StructureViewBuilder? {
-        return if(psiFile is DlangFile) DlangTreeBasedStructureViewBuilder(psiFile) else null
+        return if(psiFile is DlangPsiFile) DlangTreeBasedStructureViewBuilder(psiFile) else null
     }
 }
 
-class DlangTreeBasedStructureViewBuilder(val psiFile: DlangFile) : TreeBasedStructureViewBuilder() {
+class DlangTreeBasedStructureViewBuilder(val psiFile: DlangPsiFile) : TreeBasedStructureViewBuilder() {
     override fun createStructureViewModel(editor: Editor?): StructureViewModel = DStructureViewModel(psiFile)
 }

--- a/src/main/kotlin/io/github/intellij/dlanguage/stubs/index/DImportIndex.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/stubs/index/DImportIndex.kt
@@ -4,7 +4,7 @@ import com.google.common.collect.Sets
 import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.*
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 import io.github.intellij.dlanguage.psi.interfaces.DNamedElement
 import io.github.intellij.dlanguage.resolve.processors.parameters.DAttributesFinder
 import io.github.intellij.dlanguage.stubs.DlangSingleImportStub
@@ -31,7 +31,7 @@ class DPublicImportIndex : StringStubIndexExtension<SingleImport>() {
         fun <S : NamedStubBase<T>, T : DNamedElement> indexPublicImports(stub: S, sink: IndexSink) {
             if (stub is DlangSingleImportStub && topLevelDeclaration(stub)) {
                 if ((stub as DlangSingleImportStub).attributes.visibility == DAttributesFinder.Visibility.PUBLIC) {
-                    val fileName = (stub.psi.containingFile as DlangFile).getFullyQualifiedModuleName()
+                    val fileName = (stub.psi.containingFile as DlangPsiFile).getFullyQualifiedModuleName()
                     sink.occurrence(KEY, fileName)
                 }
             }

--- a/src/main/kotlin/io/github/intellij/dlanguage/stubs/index/DTopLevelDeclarationsByModule.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/stubs/index/DTopLevelDeclarationsByModule.kt
@@ -2,7 +2,7 @@ package io.github.intellij.dlanguage.stubs.index
 
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.*
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 import io.github.intellij.dlanguage.psi.named.DlangSingleImport
 import io.github.intellij.dlanguage.psi.interfaces.DNamedElement
 import io.github.intellij.dlanguage.psi.interfaces.HasMembers
@@ -21,12 +21,12 @@ class DTopLevelDeclarationsByModule : StringStubIndexExtension<DNamedElement>() 
     }
 
     companion object {
-        val KEY: StubIndexKey<String, DNamedElement> = StubIndexKey.createIndexKey<String, DNamedElement>("d.globally.accessible.module")
+        val KEY: StubIndexKey<String, DNamedElement> = StubIndexKey.createIndexKey("d.globally.accessible.module")
         val VERSION = 4
         fun <S : NamedStubBase<T>, T : DNamedElement> indexTopLevelDeclarationsByModule(stub: S, sink: IndexSink) {
             if (stub !is io.github.intellij.dlanguage.stubs.DlangIdentifierStub && topLevelDeclaration(stub)) {
-                val fileName = (stub.psi.containingFile as DlangFile).getFullyQualifiedModuleName()
-                sink.occurrence(DTopLevelDeclarationsByModule.KEY, fileName)
+                val fileName = (stub.psi.containingFile as DlangPsiFile).getFullyQualifiedModuleName()
+                sink.occurrence(KEY, fileName)
             }
         }
 

--- a/src/main/kotlin/io/github/intellij/dlanguage/utils/DPsiUtil.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/utils/DPsiUtil.kt
@@ -8,8 +8,8 @@ import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.PsiTreeUtil.findChildrenOfType
 import io.github.intellij.dlanguage.psi.DLanguageDeclaration
-import io.github.intellij.dlanguage.psi.DlangFile
 import io.github.intellij.dlanguage.psi.DLanguageParameters
+import io.github.intellij.dlanguage.psi.DlangPsiFile
 import io.github.intellij.dlanguage.psi.named.DlangSingleImport
 import io.github.intellij.dlanguage.resolve.ParameterCountRange
 import io.github.intellij.dlanguage.resolve.processors.parameters.DAttributesFinder
@@ -54,7 +54,7 @@ object DPsiUtil {
     }
 
     fun getParent(element: PsiElement, targetType: Set<IElementType>, excludedType: Set<IElementType>): PsiElement? {
-        if (element.parent == null || element is DlangFile) {
+        if (element.parent == null || element is DlangPsiFile) {
             return null
         }
 

--- a/src/test/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionClientTest.java
+++ b/src/test/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionClientTest.java
@@ -5,7 +5,7 @@ import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.util.PathUtil;
 import io.github.intellij.dlanguage.LightDlangTestCase;
 import io.github.intellij.dlanguage.codeinsight.dcd.completions.Completion;
-import io.github.intellij.dlanguage.psi.DlangFile;
+import io.github.intellij.dlanguage.psi.DlangPsiFile;
 import io.github.intellij.dlanguage.settings.ToolKey;
 import org.junit.Test;
 
@@ -23,7 +23,7 @@ public class DCDCompletionClientTest extends LightDlangTestCase {
 
     @Test
     public void testBuildDcdCommand() {
-        final DlangFile sourceFile = super.lightDlangPsiFile("app.d", "");
+        final DlangPsiFile sourceFile = super.lightDlangPsiFile("app.d", "");
         PropertiesComponent.getInstance().setValue(ToolKey.DCD_CLIENT_KEY.getFlagsKey(), null);
 
         final GeneralCommandLine commandLine = DCDCompletionClient.buildDcdCommand("dcd-client", 33, sourceFile);
@@ -35,7 +35,7 @@ public class DCDCompletionClientTest extends LightDlangTestCase {
 
     @Test
     public void testBuildDcdCommandWithDcdParams() {
-        final DlangFile sourceFile = super.lightDlangPsiFile("app.d", "");
+        final DlangPsiFile sourceFile = super.lightDlangPsiFile("app.d", "");
         PropertiesComponent.getInstance().setValue(ToolKey.DCD_CLIENT_KEY.getFlagsKey(), "one,\\test directory\\fileTwo");
 
         final GeneralCommandLine commandLine = DCDCompletionClient.buildDcdCommand("dcd-client", 0, sourceFile);

--- a/src/test/java/io/github/intellij/dlanguage/psi/DlangFileTest.java
+++ b/src/test/java/io/github/intellij/dlanguage/psi/DlangFileTest.java
@@ -15,7 +15,7 @@ public class DlangFileTest extends LightDlangTestCase {
      */
     @Test
     public void testGetModuleName_shouldBeFilenameWithoutExtension() {
-        final DlangFile dlangFile = virtualDlangPsiFile("myapp.d", "// no module defined in source");
+        final DlangPsiFileImpl dlangFile = virtualDlangPsiFile("myapp.d", "// no module defined in source");
 
         assertEquals("myapp.d", dlangFile.getName()); // should be the filename
         assertEquals("myapp", dlangFile.getModuleName());
@@ -29,7 +29,7 @@ public class DlangFileTest extends LightDlangTestCase {
      */
     @Test
     public void testGetModuleName_shouldBeFilenameWithoutExtension_IncludingPath() {
-        final DlangFile dlangFile = virtualDlangPsiFile("awesome/app.d", "// no module defined in source");
+        final DlangPsiFileImpl dlangFile = virtualDlangPsiFile("awesome/app.d", "// no module defined in source");
 
         assertEquals("app.d", dlangFile.getName()); // should be the filename
         assertEquals("app", dlangFile.getModuleName());
@@ -43,7 +43,7 @@ public class DlangFileTest extends LightDlangTestCase {
      */
     @Test
     public void testGetModuleName_HonoursTheNameDefinedInSource() {
-        final DlangFile dlangFile = virtualDlangPsiFile("myapp.d", "module realname;");
+        final DlangPsiFileImpl dlangFile = virtualDlangPsiFile("myapp.d", "module realname;");
 
         assertEquals("myapp.d", dlangFile.getName()); // should be the filename
         assertEquals("realname", dlangFile.getModuleName());
@@ -57,7 +57,7 @@ public class DlangFileTest extends LightDlangTestCase {
      */
     @Test
     public void testGetModuleName_HonoursTheNameDefinedInSource_Multipart() {
-        final DlangFile dlangFile = virtualDlangPsiFile("myapp.d", "module my.app.realname;");
+        final DlangPsiFileImpl dlangFile = virtualDlangPsiFile("myapp.d", "module my.app.realname;");
 
         assertEquals("myapp.d", dlangFile.getName());
         assertEquals("realname", dlangFile.getModuleName());
@@ -70,7 +70,7 @@ public class DlangFileTest extends LightDlangTestCase {
      */
     @Test
     public void testGetModuleName_ReturnsProperModuleName_stdio() {
-        final DlangFile dlangFile = virtualDlangPsiFile(
+        final DlangPsiFileImpl dlangFile = virtualDlangPsiFile(
             "c/stdio.d",
             "module c.stdio; // module stdio in the c package"
         );
@@ -87,7 +87,7 @@ public class DlangFileTest extends LightDlangTestCase {
     // https://dlang.org/spec/module.html
     @Test
     public void testGetModuleName_ReturnsProperModuleName_foo_bar() {
-        final DlangFile dlangFile = virtualDlangPsiFile("foo-bar.d", "module foo_bar;");
+        final DlangPsiFileImpl dlangFile = virtualDlangPsiFile("foo-bar.d", "module foo_bar;");
 
         assertEquals("foo-bar.d", dlangFile.getName());
         assertEquals("foo_bar", dlangFile.getModuleName());
@@ -98,7 +98,7 @@ public class DlangFileTest extends LightDlangTestCase {
     // https://dlang.org/spec/module.html
     @Test
     public void testGetModuleName_ReturnsProperModuleName_deprecated_foo() {
-        final DlangFile dlangFile = virtualDlangPsiFile("foo-bar.d", "deprecated module foo;");
+        final DlangPsiFileImpl dlangFile = virtualDlangPsiFile("foo-bar.d", "deprecated module foo;");
 
         assertEquals("foo-bar.d", dlangFile.getName());
         assertEquals("foo", dlangFile.getModuleName());
@@ -109,7 +109,7 @@ public class DlangFileTest extends LightDlangTestCase {
     // https://dlang.org/spec/module.html
     @Test
     public void testGetModuleName_ReturnsProperModuleName_deprecated_foo_with_message() {
-        final DlangFile dlangFile = virtualDlangPsiFile("foo-bar.d", "deprecated(\"Please use foo2 instead.\") module foo;");
+        final DlangPsiFileImpl dlangFile = virtualDlangPsiFile("foo-bar.d", "deprecated(\"Please use foo2 instead.\") module foo;");
 
         assertEquals("foo-bar.d", dlangFile.getName());
         assertEquals("foo", dlangFile.getModuleName());
@@ -126,7 +126,7 @@ public class DlangFileTest extends LightDlangTestCase {
      */
     @Test
     public void testGetModuleName_HandlesInvalidModuleName() {
-        final DlangFile dlangFile = virtualDlangPsiFile("foo-bar.d", "");
+        final DlangPsiFileImpl dlangFile = virtualDlangPsiFile("foo-bar.d", "");
 
         assertEquals("foo-bar.d", dlangFile.getName());
         assertNotNull("Should return file name without extension", dlangFile.getModuleName());

--- a/src/test/kotlin/io/github/intellij/dlanguage/LightDlangTestCase.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/LightDlangTestCase.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.FileViewProvider
 import com.intellij.psi.SingleRootFileViewProvider
 import com.intellij.testFramework.LightPlatform4TestCase
 import com.intellij.testFramework.LightVirtualFile
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFileImpl
 import com.intellij.testFramework.VfsTestUtil
 
 /**
@@ -20,12 +20,12 @@ abstract class LightDlangTestCase : LightPlatform4TestCase() {
         return VfsTestUtil.createFile(sourcesRoot, filename, content)
     }
 
-    fun virtualDlangPsiFile(filename: String, content: String): DlangFile {
+    fun virtualDlangPsiFile(filename: String, content: String): DlangPsiFileImpl {
         val provider: FileViewProvider = SingleRootFileViewProvider(
             MockPsiManager(project),
             addFileToModuleSource(filename, content)
         )
-        return DlangFile(provider)
+        return DlangPsiFileImpl(provider)
     }
 
     /**
@@ -44,12 +44,12 @@ abstract class LightDlangTestCase : LightPlatform4TestCase() {
      * @param content the file content (source code)
      * @return a Dlang Psi File from a single LightVirtualFile (In-memory implementation of [VirtualFile])
      */
-    fun lightDlangPsiFile(filename: String, content: String): DlangFile {
+    fun lightDlangPsiFile(filename: String, content: String): DlangPsiFileImpl {
         val provider: FileViewProvider = SingleRootFileViewProvider(
             MockPsiManager(project),
             lightDlangVirtualFile(filename, content)
         )
-        return DlangFile(provider)
+        return DlangPsiFileImpl(provider)
     }
 
 }

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.impl.PsiManagerEx
 import com.intellij.psi.impl.source.resolve.reference.impl.PsiMultiReference
 import io.github.intellij.dlanguage.DLightPlatformCodeInsightFixtureTestCase
 import io.github.intellij.dlanguage.psi.DLanguageClassDeclaration
-import io.github.intellij.dlanguage.psi.DlangFile
+import io.github.intellij.dlanguage.psi.DlangPsiFileImpl
 import io.github.intellij.dlanguage.psi.named.DlangConstructor
 import io.github.intellij.dlanguage.psi.named.DlangFunctionDeclaration
 import io.github.intellij.dlanguage.psi.named.DlangIdentifier
@@ -159,8 +159,8 @@ abstract class DResolveTestCase : DLightPlatformCodeInsightFixtureTestCase("reso
         val element = referencedElement!!.resolve()
         if (resolvedFileName != null) {
             assertNotNull("Referenced not resolved", element)
-            assertInstanceOf(element!!, DlangFile::class.java)
-            assertEquals((element as DlangFile).name, resolvedFileName)
+            assertInstanceOf(element!!, DlangPsiFileImpl::class.java)
+            assertEquals((element as DlangPsiFileImpl).name, resolvedFileName)
         } else {
             assertNull(element)
         }

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
@@ -1,17 +1,13 @@
 package io.github.intellij.dlanguage.resolve
 
-import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.CharsetToolkit
-import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFileFilter
-import com.intellij.openapi.vfs.writeText
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.psi.impl.PsiManagerEx
 import com.intellij.psi.impl.source.resolve.reference.impl.PsiMultiReference
-import com.intellij.testFramework.utils.vfs.createFile
 import io.github.intellij.dlanguage.DLightPlatformCodeInsightFixtureTestCase
 import io.github.intellij.dlanguage.psi.DLanguageClassDeclaration
 import io.github.intellij.dlanguage.psi.DlangFile


### PR DESCRIPTION
And also rename DFile to DPsiFileImpl

Using the interface is generally better as it allow to decouple with the implementation, and will allow a future split of api and implementation being separated.