### PR TITLE
Fix a potential null pointer exception

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/utils/DUtil.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/utils/DUtil.kt
@@ -66,14 +66,14 @@ object DUtil {
      * @return the class or struct containing this constructor/method. returns null if not found
      */
     @JvmStatic
-    fun getParentClassOrStructOrTemplateOrInterfaceOrUnion(namedElement: PsiElement?): DNamedElement {
+    fun getParentClassOrStructOrTemplateOrInterfaceOrUnion(namedElement: PsiElement?): DNamedElement? {
         return PsiTreeUtil.getParentOfType(
             namedElement,
             DlangInterfaceOrClass::class.java,
             DlangStructDeclaration::class.java,
             DlangTemplateDeclaration::class.java,
             DlangUnionDeclaration::class.java
-        )!!
+        )
     }
 
     fun getPrevSiblingOfType(


### PR DESCRIPTION
A static module constructor does not have a parent class or interface, then this method should return null.
The docs already says it can return null, so no need of !!