### PR TITLE
Fix the rename implementation

### DIFF
--- a/src/main/java/io/github/intellij/dlanguage/psi/impl/DNamedStubbedPsiElementBase.java
+++ b/src/main/java/io/github/intellij/dlanguage/psi/impl/DNamedStubbedPsiElementBase.java
@@ -55,7 +55,12 @@ public abstract class DNamedStubbedPsiElementBase<T extends DNamedStubBase<?>> e
         if (getNameIdentifier() == null) {
             throw new IncorrectOperationException("Cannot rename. Identifier was Null");
         }
-        PsiImplUtil.setName(Objects.requireNonNull(getNameIdentifier()), newName);
+        getNameIdentifier().replace(
+            Objects.requireNonNull(DElementFactory.createDLanguageIdentifierFromText(
+                getProject(),
+                newName
+            ))
+        );
         return this;
     }
 


### PR DESCRIPTION
With previous implementation, the new node was replaced by a Java node, so all references were lost after the rename. A reparse (text modification) was needed to rehave the PSI correct and references resolving back to what they should.

Tested by calling rename on a file and seeing the references still being referencing without other modification. A unit test can be added for this, to ensure that the renamed Psi node is still a valid D node.