### PR TITLE
Add dlang tools to coverage actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,8 @@ jobs:
               with:
                   distribution: temurin
                   java-version: 21
+            - name: Install D compiler
+              uses: dlang-community/setup-dlang@v1
 
             - name: Kover coveralls.io
               # Disable configuration cache for this task for now https://github.com/kt3k/coveralls-gradle-plugin/issues/117


### PR DESCRIPTION
To build generated PSI, it needs rdmd, so install it before generating coverage reports.