### PR TITLE
Add psiViewer plugin for local dev

### DIFF
--- a/dlang/plugin-impl/build.gradle.kts
+++ b/dlang/plugin-impl/build.gradle.kts
@@ -82,6 +82,10 @@ dependencies {
             "com.intellij.copyright"
         )
 
+        // If not run by CICD, add some useful dev plugins
+        if (providers.environmentVariable("CI").orNull == null)
+            plugin("psiViewer:${properties("psiViewerVersion")}")
+
         pluginVerifier()
         zipSigner()
         instrumentationTools()

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,8 @@ ideaVersion = 2024.2
 pluginSinceBuild = 242
 pluginUntilBuild = 242.*
 
+psiViewerVersion = 242.4697
+
 # set via CI
 publishChannels=
 org.gradle.logging.level=info


### PR DESCRIPTION
This plugin is really useful when developping a language plugin, so it’s usefull to always having it when starting a local instance. However don’t install it for CICD as it’s not useful there and the version may be incompatible with the variety of IDE version it covers.