### PR TITLE
Fix coverage of psi-* modules not included

### DIFF
--- a/dlang/plugin-impl/build.gradle.kts
+++ b/dlang/plugin-impl/build.gradle.kts
@@ -97,7 +97,13 @@ dependencies {
     }
 
     // theses kover lines are here to generate a merged report of all the projects
-    rootProject.allprojects
-        .filter { it.extensions.findByName("kover") != null }
-        .forEach { kover(it) }
+    kover (project(":"))
+    kover (project(":utils"))
+    // don’t include errorreporting as it contains no useful code to cover (not covered by tests)
+    // kover (project(":errorreporting"))
+    kover (project(":debugger"))
+    kover (project(":sdlang"))
+    kover (project(":dub"))
+    kover (project(":dlang:psi-api"))
+    kover (project(":dlang:psi-impl"))
 }

--- a/errorreporting/build.gradle.kts
+++ b/errorreporting/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("java")
     alias(libs.plugins.kotlin)
     alias(libs.plugins.gradleIntelliJModule)
-    alias(libs.plugins.kover)
 }
 
 


### PR DESCRIPTION
For some reason the "automatic apply" method does not work (the "kover" extension does not appear for them). So fallback to the manual method of adding them line by line.
Also removed errorreporting module as it’s not covered by test and don’t contains useful code to cover.

I checked in the aggregated report that psi-api classes and psi-impl classes appear