### PR TITLE
Delete generated folders (gen) when executing the clean task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,11 @@ sourceSets {
     }
 }
 
+tasks.clean {
+    val dir = project.file("gen")
+    delete(dir)
+}
+
 tasks.register<Test>("testCompilation") {
     group = "Verification"
     dependsOn(tasks.classes, tasks.testClasses)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,8 +11,8 @@ gradle.startParameter.showStacktrace = ShowStacktrace.ALWAYS
 fun properties(key: String) = providers.gradleProperty(key).get()
 
 plugins {
-    id("org.gradle.idea")
     id("java")
+    id("org.gradle.idea")
     alias(libs.plugins.kotlin)
     alias(libs.plugins.gradleIntelliJModule)
     alias(libs.plugins.gradleIntelliJPlatform).apply(false) // required to prevent resolution error
@@ -126,5 +126,12 @@ dependencies {
         )
         instrumentationTools()
         testFramework(TestFrameworkType.Plugin.Java)
+    }
+}
+
+// Mark the generated sources as generated in intellij idea
+idea {
+    module {
+        generatedSourceDirs = setOf(file("gen"))
     }
 }

--- a/dlang/psi-api/build.gradle.kts
+++ b/dlang/psi-api/build.gradle.kts
@@ -1,5 +1,5 @@
+
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
-import org.jetbrains.intellij.platform.gradle.utils.asPath
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.nio.file.Files
 
@@ -51,6 +51,11 @@ tasks.withType<KotlinCompile>().configureEach {
     dependsOn(
         generatePsi,
     )
+}
+
+tasks.clean {
+    val dir = project.file("gen")
+    delete(dir)
 }
 
 dependencies {

--- a/dlang/psi-api/build.gradle.kts
+++ b/dlang/psi-api/build.gradle.kts
@@ -5,6 +5,7 @@ import java.nio.file.Files
 
 plugins {
     id("java")
+    id("org.gradle.idea")
     alias(libs.plugins.kotlin)
     alias(libs.plugins.gradleIntelliJModule)
     alias(libs.plugins.kover)
@@ -67,5 +68,12 @@ dependencies {
         intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
         instrumentationTools()
         testFramework(TestFrameworkType.Platform)
+    }
+}
+
+// Mark the generated sources as generated in intellij idea
+idea {
+    module {
+        generatedSourceDirs = setOf(file("gen"))
     }
 }

--- a/dlang/psi-api/build.gradle.kts
+++ b/dlang/psi-api/build.gradle.kts
@@ -1,6 +1,5 @@
 
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.nio.file.Files
 
 plugins {
@@ -18,19 +17,10 @@ repositories {
     }
 }
 
-sourceSets {
-    main {
-        java.srcDirs("src/main/java", "src/main/kotlin", "gen" , "src/main/jflex")
-    }
-    test {
-        java.srcDirs("src/test/java", "src/test/kotlin")
-    }
-}
-
-
 val ensureDirectory = tasks.register("ensureDirectory") {
     val file = file("gen/io/github/intellij/dlanguage/psi/")
-    doLast {
+    outputs.dir("gen/io/github/intellij/dlanguage/psi")
+    doFirst {
         Files.createDirectories(file.toPath())
     }
 }
@@ -42,21 +32,24 @@ val generatePsi = tasks.register<Exec>("generatePsi") {
     args("${rootProject.projectDir}/scripts/types_regen_script.d", "Interface")
 }
 
-tasks.withType<JavaCompile>().configureEach {
+val generate by tasks.registering {
+    outputs.dirs("gen")
     dependsOn(
         generatePsi,
     )
 }
 
-tasks.withType<KotlinCompile>().configureEach {
-    dependsOn(
-        generatePsi,
-    )
+sourceSets {
+    main {
+        java.srcDirs("src/main/java", "src/main/kotlin", generate, "src/main/jflex")
+    }
+    test {
+        java.srcDirs("src/test/java", "src/test/kotlin")
+    }
 }
 
 tasks.clean {
-    val dir = project.file("gen")
-    delete(dir)
+    delete(generate)
 }
 
 dependencies {

--- a/dlang/psi-impl/build.gradle.kts
+++ b/dlang/psi-impl/build.gradle.kts
@@ -27,6 +27,11 @@ sourceSets {
     }
 }
 
+tasks.clean {
+    val dir = project.file("gen")
+    delete(dir)
+}
+
 val generateSyntaxLexer = tasks.register<GenerateLexerTask>("generateSyntaxLexer") {
     // source flex file
     sourceFile.set(file("src/main/jflex/io/github/intellij/dlanguage/lexer/DLanguageLexer.flex"))

--- a/dlang/psi-impl/build.gradle.kts
+++ b/dlang/psi-impl/build.gradle.kts
@@ -5,6 +5,7 @@ import java.nio.file.Files
 
 plugins {
     id("java")
+    id("org.gradle.idea")
     alias(libs.plugins.kotlin)
     alias(libs.plugins.gradleIntelliJModule)
     alias(libs.plugins.grammarkit)
@@ -79,5 +80,12 @@ dependencies {
         intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
         instrumentationTools()
         testFramework(TestFrameworkType.Platform)
+    }
+}
+
+// Mark the generated sources as generated in intellij idea
+idea {
+    module {
+        generatedSourceDirs = setOf(file("gen"))
     }
 }

--- a/dlang/psi-impl/build.gradle.kts
+++ b/dlang/psi-impl/build.gradle.kts
@@ -43,7 +43,7 @@ val generateSyntaxLexer = tasks.register<GenerateLexerTask>("generateSyntaxLexer
 
 
 val ensureDirectory = tasks.register("ensureDirectory") {
-    val file = file("gen/io/github/intellij/dlanguage/psi/")
+    val file = file("gen/io/github/intellij/dlanguage/psi/impl")
     doLast {
         Files.createDirectories(file.toPath())
     }

--- a/scripts/types_regen_script.d
+++ b/scripts/types_regen_script.d
@@ -925,7 +925,7 @@ int main(string[] args) {
     bool genInterface = args[1] == "Interface";
 
     // preparatory work
-    if (!exists("impl"))
+    if (!genInterface && !exists("impl"))
         mkdir("impl");
 
     foreach(string key; types_children.keys) {

--- a/sdlang/build.gradle.kts
+++ b/sdlang/build.gradle.kts
@@ -1,7 +1,7 @@
+
 import org.jetbrains.grammarkit.tasks.GenerateLexerTask
 import org.jetbrains.grammarkit.tasks.GenerateParserTask
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 
 plugins {
@@ -32,22 +32,6 @@ dependencies {
     }
 }
 
-
-sourceSets {
-    main {
-        java.srcDirs("src/main/kotlin", "gen")
-        // resources.srcDirs "src/main/resources" // specifying the default causes a problem with processResources on Gradle 7
-    }
-    test {
-        java.srcDirs("src/test/kotlin")
-    }
-}
-
-tasks.clean {
-    val dir = project.file("gen")
-    delete(dir)
-}
-
 val generateSyntaxLexer = tasks.register<GenerateLexerTask>("generateSyntaxLexer") {
     // source flex file
     sourceFile.set(file("src/main/kotlin/io/github/intellij/dlanguage/sdlang/lexer/SDLangLexer.flex"))
@@ -63,8 +47,23 @@ val generateSyntaxParser = tasks.register<GenerateParserTask>("generateSyntaxPar
     pathToPsiRoot.set("io/github/intellij/dlanguage/sdlang/psi")
 }
 
-tasks.withType<KotlinCompile>().configureEach {
+val generate by tasks.registering {
+    outputs.dir("gen")
     dependsOn(generateSyntaxLexer, generateSyntaxParser)
+}
+
+sourceSets {
+    main {
+        java.srcDirs("src/main/kotlin", generate)
+        // resources.srcDirs "src/main/resources" // specifying the default causes a problem with processResources on Gradle 7
+    }
+    test {
+        java.srcDirs("src/test/kotlin")
+    }
+}
+
+tasks.clean {
+    delete(generate)
 }
 
 // Mark the generated sources as generated in intellij idea

--- a/sdlang/build.gradle.kts
+++ b/sdlang/build.gradle.kts
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("java")
+    id("org.gradle.idea")
     alias(libs.plugins.kotlin)
     alias(libs.plugins.grammarkit)
     alias(libs.plugins.gradleIntelliJModule)
@@ -65,3 +66,11 @@ val generateSyntaxParser = tasks.register<GenerateParserTask>("generateSyntaxPar
 tasks.withType<KotlinCompile>().configureEach {
     dependsOn(generateSyntaxLexer, generateSyntaxParser)
 }
+
+// Mark the generated sources as generated in intellij idea
+idea {
+    module {
+        generatedSourceDirs = setOf(file("gen"))
+    }
+}
+

--- a/sdlang/build.gradle.kts
+++ b/sdlang/build.gradle.kts
@@ -42,6 +42,10 @@ sourceSets {
     }
 }
 
+tasks.clean {
+    val dir = project.file("gen")
+    delete(dir)
+}
 
 val generateSyntaxLexer = tasks.register<GenerateLexerTask>("generateSyntaxLexer") {
     // source flex file


### PR DESCRIPTION
With this change, running `gradle clean` will delete the generated folders and so no artifact of a previous build will remain (useful when a Psi change happened).