### PR TITLE
Fix null pointer exception in doc rendering due to wrong type

### DIFF
--- a/scripts/types_regen_script.d
+++ b/scripts/types_regen_script.d
@@ -336,7 +336,7 @@ static this() {
     types_extra_interfaces["TemplateTypeParameter"] = ["TemplateParameter"];
     stub_children["TemplateValueParameter"] = ["Type","Identifier","OP_COLON","AssignExpression",  "TemplateValueParameterDefault"];
     types_extra_interfaces["TemplateValueParameter"] = ["TemplateParameter"];
-    types_children["TemplateValueParameterDefault"] = ["OP_EQ","AssignExpression","KW___FILE__","KW___FUNCTION__","KW___LINE__","KW___MODULE__","KW___PRETTY_FUNCTION__"];
+    types_children["TemplateValueParameterDefault"] = ["OP_EQ","Expression"];
     types_children["TernaryExpression"] = ["OP_QUEST","OP_COLON","Expression*"];
     types_extra_interfaces["TernaryExpression"] = ["Expression"];
     types_children["ThrowExpression"] = ["KW_THROW","Expression","OP_SCOLON"];

--- a/src/main/kotlin/io/github/intellij/dlanguage/features/documentation/DSignatureDocGenerator.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/features/documentation/DSignatureDocGenerator.kt
@@ -289,7 +289,8 @@ class DSignatureDocGenerator {
             appendType(builder, element.type)
             builder.append(" ").append(element.identifier!!.text)
             if (element.templateValueParameterDefault != null) {
-                builder.append(" = ").append(element.templateValueParameterDefault!!.assignExpression!!.text)
+                // TODO properly handle expression (add coloration of literals, ...)
+                builder.append(" = ").append(element.templateValueParameterDefault!!.expression!!.text)
             }
         }
     }


### PR DESCRIPTION
With Psi simplification, the expression value may directly be a LiteralExpression instead of the whole tree of
assignExpression(.(.(.(literalExpression)))). Fix this behavior otherwise, we get a null when looking for an assignExpression where it’s actually a simple literalExpression.