### PR TITLE
Lazily parse statements blocks

### DIFF
--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/parser/DLangParser.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/parser/DLangParser.kt
@@ -2,6 +2,7 @@ package io.github.intellij.dlanguage.parser
 
 import com.google.common.collect.Sets
 import com.intellij.lang.PsiBuilder
+import com.intellij.lang.PsiBuilderUtil
 import com.intellij.psi.tree.IElementType
 import io.github.intellij.dlanguage.psi.DlangTypes
 import java.util.*
@@ -1446,6 +1447,15 @@ internal class DLangParser(private val builder: PsiBuilder) {
         }
         exit_section_modified(builder, m, DlangTypes.AUTO_ASSIGNMENT, true)
         return true
+    }
+
+    fun parseBlocStatementLazy(): Boolean {
+        val openBrace = expect(DlangTypes.OP_BRACES_LEFT)
+        if (openBrace == null) {
+            return false
+        }
+        val marker = PsiBuilderUtil.parseBlockLazy(builder, DlangTypes.OP_BRACES_LEFT, DlangTypes.OP_BRACES_RIGHT, DlangTypes.BLOCK_STATEMENT)
+        return marker != null
     }
 
     /**

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/CodeBlockElementType.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/CodeBlockElementType.kt
@@ -1,0 +1,76 @@
+package io.github.intellij.dlanguage.psi
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.Language
+import com.intellij.lang.LanguageParserDefinitions
+import com.intellij.lang.LighterASTNode
+import com.intellij.lang.LighterLazyParseableNode
+import com.intellij.lang.PsiBuilderFactory
+import com.intellij.lang.PsiBuilderUtil
+import com.intellij.openapi.project.Project
+import com.intellij.psi.tree.ICompositeElementType
+import com.intellij.psi.tree.IErrorCounterReparseableElementType
+import com.intellij.psi.tree.ILightLazyParseableElementType
+import com.intellij.util.diff.FlyweightCapableTreeStructure
+import io.github.intellij.dlanguage.DLanguage
+import io.github.intellij.dlanguage.parser.DLangParser
+import io.github.intellij.dlanguage.psi.impl.DLanguageBlockStatementImpl
+
+class CodeBlockElementType(name: String) : IErrorCounterReparseableElementType(name, DLanguage),
+    ICompositeElementType, ILightLazyParseableElementType {
+
+    override fun createNode(text: CharSequence?): ASTNode? = DLanguageBlockStatementImpl(text)
+    override fun createCompositeNode(): ASTNode = DLanguageBlockStatementImpl(null)
+
+    override fun parseContents(chameleon: ASTNode): ASTNode? {
+        val psi = chameleon.psi
+
+        val project = psi.project
+        val parserDefinition = LanguageParserDefinitions.INSTANCE.forLanguage(language)
+
+        val builder = PsiBuilderFactory.getInstance()
+            .createBuilder(
+                project,
+                chameleon,
+                parserDefinition.createLexer(project),
+                language,
+                chameleon.chars
+            )
+
+        val parser = DLangParser(builder)
+        parser.parseStatement()
+        return builder.treeBuilt.firstChildNode
+    }
+
+    override fun parseContents(chameleon: LighterLazyParseableNode): FlyweightCapableTreeStructure<LighterASTNode?> {
+        val psi = chameleon.containingFile!!
+
+        val project = psi.project
+        val parserDefinition = LanguageParserDefinitions.INSTANCE.forLanguage(language)
+
+        val builder = PsiBuilderFactory.getInstance()
+            .createBuilder(
+                project,
+                chameleon,
+                parserDefinition.createLexer(project),
+                language,
+                chameleon.text
+            )
+
+        val parser = DLangParser(builder)
+        parser.parseStatement()
+        return builder.lightTree
+    }
+
+    override fun getErrorsCount(seq: CharSequence, fileLanguage: Language, project: Project): Int {
+        val parserDefinition = LanguageParserDefinitions.INSTANCE.forLanguage(language)
+        val lexer = parserDefinition.createLexer(project)
+        return if(PsiBuilderUtil.hasProperBraceBalance(seq, lexer, DlangTypes.OP_BRACES_LEFT, DlangTypes.OP_BRACES_RIGHT))
+            NO_ERRORS
+        else
+            FATAL_ERROR
+    }
+
+    override fun reuseCollapsedTokens(): Boolean = true
+
+}

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/DlangTypes.java
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/DlangTypes.java
@@ -3,12 +3,9 @@ package io.github.intellij.dlanguage.psi;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.ILazyParseableElementType;
 import io.github.intellij.dlanguage.documentation.DlangDocCommentType;
 import io.github.intellij.dlanguage.psi.impl.*;
-import io.github.intellij.dlanguage.psi.impl.named.DLanguageTemplateAliasParameterImpl;
-import io.github.intellij.dlanguage.psi.impl.named.DLanguageTemplateTupleParameterImpl;
-import io.github.intellij.dlanguage.psi.impl.named.DLanguageTemplateTypeParameterImpl;
-import io.github.intellij.dlanguage.psi.impl.named.DLanguageTemplateValueParameterImpl;
 import io.github.intellij.dlanguage.psi.impl.named.*;
 
 public interface DlangTypes {
@@ -44,6 +41,8 @@ public interface DlangTypes {
     IElementType NAMED_IMPORT_BIND = DElementTypeFactory.factory("NAMED_IMPORT_BIND");
     IElementType VERSION_SPECIFICATION = DElementTypeFactory.factory("VERSION_SPECIFICATION");
     IElementType DECLARATOR_IDENTIFIER = DElementTypeFactory.factory("DECLARATOR_IDENTIFIER");
+
+    ILazyParseableElementType BLOCK_STATEMENT = new CodeBlockElementType("BLOCK_STATEMENT");
 
     DlangElementType ALIAS_ASSIGN = new DlangElementType("ALIAS_ASSIGN");
     DlangElementType ALIAS_DECLARATION = new DlangElementType("ALIAS_DECLARATION");
@@ -86,7 +85,6 @@ public interface DlangTypes {
     DlangElementType BASE_CLASS = new DlangElementType("BASE_CLASS");
     DlangElementType BASE_CLASS_LIST = new DlangElementType("BASE_CLASS_LIST");
     DlangElementType BASIC_TYPE = new DlangElementType("BASIC_TYPE");
-    DlangElementType BLOCK_STATEMENT = new DlangElementType("BLOCK_STATEMENT");
     DlangElementType BREAK_STATEMENT = new DlangElementType("BREAK_STATEMENT");
     DlangElementType CASE_RANGE_STATEMENT = new DlangElementType("CASE_RANGE_STATEMENT");
     DlangElementType CASE_STATEMENT = new DlangElementType("CASE_STATEMENT");
@@ -536,8 +534,8 @@ public interface DlangTypes {
                 return new DLanguageBaseClassListImpl(node);
             } else if (type == BASIC_TYPE) {
                 return new DLanguageBasicTypeImpl(node);
-            } else if (type == BLOCK_STATEMENT) {
-                return new DLanguageBlockStatementImpl(node);
+            //} else if (type == BLOCK_STATEMENT) {
+            //    return new DLanguageBlockStatementImpl(node);
             } else if (type == BREAK_STATEMENT) {
                 return new DLanguageBreakStatementImpl(node);
             } else if (type == CASE_RANGE_STATEMENT) {

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/impl/DLanguageBlockStatementImpl.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/impl/DLanguageBlockStatementImpl.kt
@@ -1,0 +1,52 @@
+package io.github.intellij.dlanguage.psi.impl
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.ResolveState
+import com.intellij.psi.impl.source.tree.LazyParseablePsiElement
+import com.intellij.psi.scope.PsiScopeProcessor
+import com.intellij.psi.util.PsiTreeUtil
+import io.github.intellij.dlanguage.psi.DLanguageBlockStatement
+import io.github.intellij.dlanguage.psi.DlangTypes
+import io.github.intellij.dlanguage.psi.DlangVisitor
+import io.github.intellij.dlanguage.psi.interfaces.Statement
+import io.github.intellij.dlanguage.resolve.ScopeProcessorImpl.processDeclarations
+
+class DLanguageBlockStatementImpl(text: CharSequence?) : LazyParseablePsiElement(DlangTypes.BLOCK_STATEMENT, text), DLanguageBlockStatement {
+    fun accept(visitor: DlangVisitor) {
+        visitor.visitBlockStatement(this)
+    }
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is DlangVisitor) {
+            accept(visitor)
+        } else {
+            super.accept(visitor)
+        }
+    }
+
+    override fun getStatements(): MutableList<Statement?> {
+        return PsiTreeUtil.getChildrenOfTypeAsList<Statement?>(this, Statement::class.java)
+    }
+
+    override fun getOP_BRACES_RIGHT(): PsiElement? {
+        return firstChild
+    }
+
+    override fun getOP_BRACES_LEFT(): PsiElement? {
+        return lastChild
+    }
+
+    override fun processDeclarations(
+        processor: PsiScopeProcessor,
+        state: ResolveState,
+        lastParent: PsiElement?,
+        place: PsiElement
+    ): Boolean {
+        return processDeclarations(this, processor, state, lastParent, place)
+    }
+
+    override fun toString(): String {
+        return this.javaClass.simpleName + "(" + this.elementType + ")"
+    }
+}

--- a/scripts/types_regen_script.d
+++ b/scripts/types_regen_script.d
@@ -62,6 +62,11 @@ string[] generate_stubImpl = [
     "StaticDestructor",
 ];
 
+
+string[] ignoreImplementationGeneration = [
+    "BlockStatement"
+];
+
 /*
 Associative array which contains Name of psi element as key and if it has a processDeclaration as value
 */
@@ -947,6 +952,8 @@ int main(string[] args) {
             f.write(interfaceFile);
             f.close();
         } else {
+            if (ignoreImplementationGeneration.canFind(key))
+                continue;
             // implementation
             string implClassName = "DLanguage" ~ key ~ "Impl";
             string implFile = implFileTemplate.format(getImplImports(types_children[key], key, parentClassName), implClassName, parentClassName, interfaceClassName, implClassName, key);


### PR DESCRIPTION
Apparently this should optimize parsing in some cases (I didn’t see difference). All languages plugins do this, so it should be useful.