### PR TITLE
Fix illegal state exception with null return value

### DIFF
--- a/dlang/psi-impl/src/main/java/io/github/intellij/dlanguage/psi/impl/DNamedStubbedPsiElementBase.java
+++ b/dlang/psi-impl/src/main/java/io/github/intellij/dlanguage/psi/impl/DNamedStubbedPsiElementBase.java
@@ -63,7 +63,6 @@ public abstract class DNamedStubbedPsiElementBase<T extends DNamedStubBase<?>> e
 
     public ItemPresentation getPresentation() {
         return new DlangItemPresentation(getContainingFile()) {
-            @NotNull
             @Override
             public String getPresentableText() {
                 return getName();


### PR DESCRIPTION
This is a leftover from the change of name being nullable. This is not @NotNull function, the interface marked this method as @Nullable and @NlsSafe.