### PR TITLE
Fix undefined symbol not marked as undefined with templates

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/inspections/PossiblyUndefinedSymbol.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/inspections/PossiblyUndefinedSymbol.kt
@@ -90,8 +90,7 @@ class PossiblyUndefinedSymbol : LocalInspectionTool() {
                         }
 
                         is ReferenceExpression -> {
-                            element.identifier ?: return
-                            elementToRegister = element.identifier!!
+                            elementToRegister = element.identifier?:element.templateInstance!!.identifier!!
                         }
 
                         is ImportBind -> {


### PR DESCRIPTION
in `a.Foo!int;` Foo was not marked as undefined if `a` resolved but not `Foo`. This is now the case.