### PR TITLE
Fix(#1028): add missing declaration to json module in plugin.xml

### DIFF
--- a/dub/src/main/resources/META-INF/io.github.intellij.dub.xml
+++ b/dub/src/main/resources/META-INF/io.github.intellij.dub.xml
@@ -1,7 +1,9 @@
 <idea-plugin>
 
+    <depends>com.intellij.modules.json</depends>
     <depends optional="true" config-file="dub-idea-only.xml">com.intellij.modules.java</depends>
     <depends optional="true" config-file="dub-clion-only.xml">com.intellij.modules.cidr.lang</depends>
+
     <extensions defaultExtensionNs="com.intellij">
         <!-- Tool Windows are the bits generally displayed on right hand side of Intellij (eg: Ant,Maven,Gradle)-->
         <toolWindow id="DubToolBar" anchor="right" icon="/icons/dub-ball.png"


### PR DESCRIPTION
For Dub Module, we depends on Json to check the validity of the schema (and so helps the user to determine if the dub.json is vadid and provide autocompletion). But since Intelij 2024.3, json was moved into his own module, so add it to allow the application to work correctly.

Closes #1028 