### PR TITLE
Update intellij gradle plugin to 2.2.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ mockito-kotlin = "5.4+"
 sentry = "7+"
 
 # plugins
-gradleIntelliJPlatformPlugin = "2.0.1"
+gradleIntelliJPlatformPlugin = "2.2.1"
 grammarkit = "2022.3.2.2"
 kotlin = "1.9.+"
 kover = "0.8.3"


### PR DESCRIPTION
Supersede #1017 
For some reason dependabot seems not check java dependencies