### PR TITLE
Add some type comprehension for foreach auto variables

### DIFF
--- a/dlang/psi-impl/src/main/java/io/github/intellij/dlanguage/psi/impl/named/DLanguageForeachTypeImpl.java
+++ b/dlang/psi-impl/src/main/java/io/github/intellij/dlanguage/psi/impl/named/DLanguageForeachTypeImpl.java
@@ -5,15 +5,19 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.util.PsiTreeUtil;
+import io.github.intellij.dlanguage.psi.DLanguageForeachStatement;
 import io.github.intellij.dlanguage.psi.DLanguageType;
 import io.github.intellij.dlanguage.psi.DlangVisitor;
 import io.github.intellij.dlanguage.psi.impl.DNamedStubbedPsiElementBase;
+import io.github.intellij.dlanguage.psi.named.DLanguageClassDeclaration;
 import io.github.intellij.dlanguage.psi.named.DLanguageForeachType;
-import io.github.intellij.dlanguage.psi.types.DType;
-import io.github.intellij.dlanguage.psi.types.DUnknownType;
+import io.github.intellij.dlanguage.psi.named.DLanguageStructDeclaration;
+import io.github.intellij.dlanguage.psi.types.*;
 import io.github.intellij.dlanguage.stubs.DLanguageForeachTypeStub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 import static io.github.intellij.dlanguage.psi.DlangTypes.*;
 
@@ -76,10 +80,62 @@ public class DLanguageForeachTypeImpl extends
     @Override
     @NotNull
     public DType getDType() {
-        if (getType() == null) {
+        if (getType() != null) {
+            return getType().getDType();
+        }
+        var foreach = PsiTreeUtil.getParentOfType(this, DLanguageForeachStatement.class);
+        assert foreach != null;
+        var expressionType = Objects.requireNonNull(foreach.getExpression()).getDType();
+        if (expressionType == null || expressionType instanceof DUnknownType) {
             return new DUnknownType();
         }
-        return getType().getDType();
+        var elementIdx = -1;
+        var list = Objects.requireNonNull(foreach.getForeachTypeList()).getForeachTypes();
+        for(int idx = 0; idx < list.size(); idx++) {
+            if (list.get(idx) == this) {
+                elementIdx = idx;
+                break;
+            }
+        }
+        if (elementIdx == -1) {
+            return new DUnknownType(); // safety shouldn't happen by construction
+        }
+
+        // Specs for foreach https://dlang.org/spec/statement.html#foreach-statement
+        if (foreach.getOP_DDOT() != null) {
+            // foreach range statement
+            // TODO need to determine the type from the range statement (type1 or type2 if possible)
+            return new DUnknownType();
+        }
+        switch (expressionType) {
+            case DArrayType arrayExpressionType -> {
+                if (elementIdx == 0)
+                    return arrayExpressionType.getBase();
+                return new DUnknownType(); // semantic error, this variable should not exist
+            }
+            case DAssociativeArrayType associativeArrayType -> {
+                if (elementIdx == 0) {
+                    if (list.size() > 1) // we unroll keys and values
+                        return associativeArrayType.getKeyType();
+                    return associativeArrayType.getValueType(); // we only unroll values
+                } else if (elementIdx == 1)
+                    return associativeArrayType.getValueType();
+                return new DUnknownType(); // semantic error, this variable shouldn't exist
+            }
+            case UserDefinedDType userDefinedDType -> {
+                var resolved = userDefinedDType.resolve();
+                if (resolved instanceof DLanguageStructDeclaration || resolved instanceof DLanguageClassDeclaration) {
+                    // TODO opApply or opApplyReverse, complex case need to advance semantic to find the proper method
+                    // TODO can also be range (popFront or popBack method)
+                }
+                return new DUnknownType(); // semantic error, we can't foreach over union and enum
+            }
+            // TODO delegate
+            // TODO sequence
+            default -> {
+                return new DUnknownType();
+            }
+        }
     }
 
 }

--- a/src/test/kotlin/io/github/intellij/dlanguage/types/ForeachVariableTypeTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/types/ForeachVariableTypeTest.kt
@@ -1,0 +1,36 @@
+package io.github.intellij.dlanguage.types
+
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase
+import io.github.intellij.dlanguage.DlangFileType
+import io.github.intellij.dlanguage.psi.named.DLanguageForeachType
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class ForeachVariableTypeTest : LightPlatformCodeInsightFixture4TestCase() {
+
+    @Test
+    fun testForeachVariableFromArray() {
+        doTest("int", """void foo() { int[] arr; foreach(expr; arr) { } }""")
+    }
+
+    @Test
+    fun testForeachVariableFromAssociativeArray() {
+        doTest("int", """void foo() { int[char] arr; foreach(expr; arr) { } }""")
+        doTest("char", """void foo() { int[char] arr; foreach(expr, a; arr) { } }""")
+        doTest("int", """void foo() { int[char] arr; foreach(a, expr; arr) { } }""")
+        doTest("int", """void foo() { int[char] arr; foreach(a, ref expr; arr) { } }""")
+    }
+
+    private fun doTest(expectedType: String, @Language("D") text: String) =
+        checkTypes(expectedType, parseForeach(text))
+
+    private fun parseForeach(text: String): DLanguageForeachType {
+        myFixture.configureByText(DlangFileType, text)
+        return myFixture.findElementByText("expr", DLanguageForeachType::class.java)
+    }
+
+    private fun checkTypes(expectedType: String, expr: DLanguageForeachType) {
+        assertNotNull(expr)
+        assertEquals(expectedType, expr.dType.toString())
+    }
+}


### PR DESCRIPTION
The support is not complete as a lot of advance semantic support is missing to properly handle everything, but at least add support for type resolution in simple cases of auto variables of foreach.

The code was made to be robust and return unknown type for all unsupported and illegal cases