### PR TITLE
Harden the code block element reparsing

### DIFF
--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/parser/DLangParser.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/parser/DLangParser.kt
@@ -1448,9 +1448,8 @@ internal class DLangParser(private val builder: PsiBuilder) {
         return true
     }
 
-    fun parseBlocStatementLazy(): Boolean {
-        val openBrace = expect(DlangTypes.OP_BRACES_LEFT)
-        if (openBrace == null) {
+    fun parseBlockStatement(): Boolean {
+        if (builder.tokenType !== DlangTypes.OP_BRACES_LEFT) {
             return false
         }
         val marker = PsiBuilderUtil.parseBlockLazy(builder, DlangTypes.OP_BRACES_LEFT, DlangTypes.OP_BRACES_RIGHT, DlangTypes.BLOCK_STATEMENT)
@@ -1465,7 +1464,7 @@ internal class DLangParser(private val builder: PsiBuilder) {
      * $(LITERAL '{') $(RULE statement)* $(LITERAL '}')
      * ;)
      */
-    fun parseBlockStatement(): Boolean {
+    fun parseBlockStatementDeep(): Boolean {
         val m = builder.mark()
         val openBrace = expect(DlangTypes.OP_BRACES_LEFT)
         if (openBrace == null) {

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/CodeBlockElementType.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/CodeBlockElementType.kt
@@ -56,14 +56,19 @@ class CodeBlockElementType(name: String) : IErrorCounterReparseableElementType(n
 
     private fun parseStatement(builder: PsiBuilder) {
         val parser = DLangParser(builder)
-        val m = builder.mark()
-        parser.parseStatement()
+        parser.parseBlockStatementDeep()
         // if the pared code is invalid, the parser may not have cover everything
         // ensure to go until the end
+        var error: PsiBuilder.Marker? = null
+        if (!builder.eof()) {
+            error = builder.mark()
+        }
         while (!builder.eof()) {
             builder.advanceLexer()
         }
-        m.done(this)
+        if (error != null) {
+            error.error("Unable to parse statement")
+        }
     }
 
     override fun getErrorsCount(seq: CharSequence, fileLanguage: Language, project: Project): Int {

--- a/src/test/resources/gold/parser/expected/statements_unterminated_if.txt
+++ b/src/test/resources/gold/parser/expected/statements_unterminated_if.txt
@@ -17,4 +17,4 @@ D Language File
           <empty list>
         PsiErrorElement:Expected } instead of EOF
           <empty list>
-    PsiComment(DlangTokenType.BLOCK_COMMENT)('/*Comment started\n}')
+        PsiComment(DlangTokenType.BLOCK_COMMENT)('/*Comment started\n}')


### PR DESCRIPTION
With some invalid code, the parser could stop eagerly and do not parse everyting. Add a recovery code to ensure that the whole text is covered by the builder and the IDE is happy.

This could be really improved (with better detection of errors and recovening in the parser itself but it will be done in a dedicated PR of better errors detections).