### PR TITLE
fix(951): add navigation aware navbar

### DIFF
--- a/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
+++ b/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
@@ -267,6 +267,8 @@
         <!-- Structure View -->
         <lang.psiStructureViewFactory language="D" implementationClass="io.github.intellij.dlanguage.structure.DStructureViewFactory"/>
 
+        <navbar implementation="io.github.intellij.dlanguage.structure.DLanguageStructureAwareNavbar"/>
+
         <!-- Show a widget in the status bar to indicate whether DCD Server is running or not -->
         <statusBarWidgetFactory id="DCD Server status" order="first" implementation="io.github.intellij.dlanguage.dcd.server.DCDServerStatusBarWidgetFactory" />
 

--- a/src/main/kotlin/io/github/intellij/dlanguage/structure/DLanguageStructureAwareNavbar.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/structure/DLanguageStructureAwareNavbar.kt
@@ -1,0 +1,46 @@
+package io.github.intellij.dlanguage.structure
+
+import com.intellij.ide.navigationToolbar.StructureAwareNavBarModelExtension
+import com.intellij.lang.Language
+import com.intellij.psi.PsiElement
+import io.github.intellij.dlanguage.DLanguage
+import io.github.intellij.dlanguage.presentation.getPresentationIcon
+import io.github.intellij.dlanguage.psi.DLanguageTemplateMixinDeclaration
+import io.github.intellij.dlanguage.psi.interfaces.UserDefinedType
+import io.github.intellij.dlanguage.psi.named.DLanguageFunctionDeclaration
+import io.github.intellij.dlanguage.psi.named.DLanguageTemplateDeclaration
+import javax.swing.Icon
+
+class DLanguageStructureAwareNavbar : StructureAwareNavBarModelExtension() {
+
+    override val language: Language get() = DLanguage
+
+    override fun getPresentableText(element: Any?): String? {
+        if (element is UserDefinedType)
+            return element.name
+        if (element is DLanguageFunctionDeclaration) {
+            return element.name
+        }
+        if (element is DLanguageTemplateDeclaration) {
+            return element.name
+        }
+        if (element is DLanguageTemplateMixinDeclaration) {
+            return element.identifier?.text
+        }
+        return null
+    }
+
+    override fun getIcon(element: Any?): Icon? {
+        return if (element is PsiElement)
+            getPresentationIcon(element)
+        else
+            super.getIcon(element)
+    }
+
+    override fun getParent(psiElement: PsiElement?): PsiElement? {
+        val parent = super.getParent(psiElement)
+        if (parent != null)
+            return parent
+        return psiElement?.containingFile
+    }
+}

--- a/src/main/kotlin/io/github/intellij/dlanguage/structure/DStructureViewFactory.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/structure/DStructureViewFactory.kt
@@ -15,5 +15,5 @@ class DStructureViewFactory : PsiStructureViewFactory {
 }
 
 class DlangTreeBasedStructureViewBuilder(val psiFile: DlangPsiFile) : TreeBasedStructureViewBuilder() {
-    override fun createStructureViewModel(editor: Editor?): StructureViewModel = DStructureViewModel(psiFile)
+    override fun createStructureViewModel(editor: Editor?): StructureViewModel = DStructureViewModel(editor, psiFile)
 }

--- a/src/main/kotlin/io/github/intellij/dlanguage/structure/DStructureViewModel.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/structure/DStructureViewModel.kt
@@ -4,15 +4,45 @@ import com.intellij.ide.structureView.StructureViewModel
 import com.intellij.ide.structureView.StructureViewModelBase
 import com.intellij.ide.structureView.StructureViewTreeElement
 import com.intellij.ide.util.treeView.smartTree.Sorter
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import io.github.intellij.dlanguage.psi.DLanguageTemplateMixinDeclaration
+import io.github.intellij.dlanguage.psi.DLanguageUnittest
+import io.github.intellij.dlanguage.psi.DlangPsiFile
+import io.github.intellij.dlanguage.psi.interfaces.UserDefinedType
+import io.github.intellij.dlanguage.psi.named.DLanguageFunctionDeclaration
+import io.github.intellij.dlanguage.psi.named.DLanguageTemplateDeclaration
 
-class DStructureViewModel(psiFile: PsiFile) :
-    StructureViewModelBase(psiFile, DStructureViewElement(psiFile)),
+class DStructureViewModel(editor: Editor?, psiFile: PsiFile) :
+    StructureViewModelBase(psiFile, editor, DStructureViewElement(psiFile)),
     StructureViewModel.ElementInfoProvider
 {
-    override fun getSorters(): Array<Sorter> = arrayOf(Sorter.ALPHA_SORTER)
+    init {
+        withSuitableClasses(
+            DLanguageTemplateMixinDeclaration::class.java,
+            DLanguageTemplateDeclaration::class.java,
+            UserDefinedType::class.java,
+            DLanguageFunctionDeclaration::class.java,
+        )
+        withSorters(Sorter.ALPHA_SORTER)
+    }
 
-    override fun isAlwaysShowsPlus(structureViewTreeElement: StructureViewTreeElement?): Boolean = false
+    override fun isAlwaysShowsPlus(structureViewTreeElement: StructureViewTreeElement?): Boolean =
+        structureViewTreeElement?.value is DlangPsiFile || structureViewTreeElement?.value is UserDefinedType
 
     override fun isAlwaysLeaf(structureViewTreeElement: StructureViewTreeElement?): Boolean = false
+
+    override fun isSuitable(element: PsiElement?): Boolean {
+        val suitable = super.isSuitable(element)
+        if (!suitable) return false
+
+        if (PsiTreeUtil.getParentOfType(element, DLanguageUnittest::class.java) != null) {
+            // We ignore the sub-elements in Unittests
+            return false
+        }
+
+        return true
+    }
 }


### PR DESCRIPTION
With this feature, the navigation bar will show the current context more precisely (if we are in a fuction or in a class).

Note: no test was added because Jetbrains does not export his utility function to test it (the one it uses for Java and Kotlin)

Closes #951 