### PR TITLE
fix(#1040): display the documentation when hovering an element

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/features/DDocumentationProvider.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/features/DDocumentationProvider.kt
@@ -1,7 +1,10 @@
 package io.github.intellij.dlanguage.features
 
 import com.intellij.lang.documentation.AbstractDocumentationProvider
-import com.intellij.psi.*
+import com.intellij.psi.PsiDocCommentBase
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.SyntaxTraverser
 import com.intellij.psi.util.PsiTreeUtil
 import io.github.intellij.dlanguage.documentation.psi.DlangDocComment
 import io.github.intellij.dlanguage.features.documentation.DDocGenerator
@@ -10,8 +13,6 @@ import io.github.intellij.dlanguage.psi.DlangPsiFile
 import io.github.intellij.dlanguage.psi.impl.named.DlangSingleImportImpl
 import io.github.intellij.dlanguage.psi.interfaces.DNamedElement
 import io.github.intellij.dlanguage.psi.named.DLanguageSingleImport
-import io.github.intellij.dlanguage.utils.TemplateDeclaration
-import io.github.intellij.dlanguage.utils.TemplateMixinDeclaration
 import java.util.function.Consumer
 
 /**
@@ -98,30 +99,11 @@ class DDocumentationProvider : AbstractDocumentationProvider() {
         if (element is DNamedElement) {
             val builder = StringBuilder()
             var declarationElement = element
-            if (declarationElement is TemplateDeclaration && declarationElement.parent is TemplateMixinDeclaration)
-                declarationElement = declarationElement.parent
-            DSignatureDocGenerator().appendDeclarationHeader(builder, declarationElement!!, element)
+            DSignatureDocGenerator().appendDeclarationHeader(builder, declarationElement, element)
             val doc = DDocGenerator().generateDoc(element)
             builder.append(doc)
             return builder.toString().ifBlank { null }
         }
         return super.generateDoc(element, originalElement)
     }
-
-    override fun getDocumentationElementForLookupItem(
-        psiManager: PsiManager,
-        `object`: Any,
-        element: PsiElement
-    ): PsiElement? {
-        return null
-    }
-
-    override fun getDocumentationElementForLink(
-        psiManager: PsiManager,
-        link: String,
-        context: PsiElement
-    ): PsiElement? {
-        return null
-    }
-
 }

--- a/src/test/kotlin/io/github/intellij/dlanguage/features/DDocumentationProviderTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/features/DDocumentationProviderTest.kt
@@ -1,7 +1,10 @@
 package io.github.intellij.dlanguage.features
 
 import com.intellij.codeInsight.documentation.DocumentationManager
+import com.intellij.psi.util.startOffset
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase
+import io.github.intellij.dlanguage.psi.named.DLanguageClassDeclaration
+import io.github.intellij.dlanguage.psi.named.DLanguageFunctionDeclaration
 import org.junit.Test
 
 class DDocumentationProviderTest : LightPlatformCodeInsightFixture4TestCase() {
@@ -101,8 +104,10 @@ class DDocumentationProviderTest : LightPlatformCodeInsightFixture4TestCase() {
     fun testGenerateDocForFileBasedExample() {
         myFixture.configureByFile("example.d")
 
+        val doSomethingMethod = myFixture.findElementByText("doSomething", DLanguageFunctionDeclaration::class.java)
+
         // put the caret on the doSomething() function in the source file
-        myFixture.editor.caretModel.moveToOffset(40)
+        myFixture.editor.caretModel.moveToOffset(doSomethingMethod!!.identifier!!.startOffset)
         val docElement = DocumentationManager.getInstance(project)
             .findTargetElement(myFixture.editor, myFixture.file)
         val text = provider!!.generateDoc(docElement, null)
@@ -111,5 +116,22 @@ class DDocumentationProviderTest : LightPlatformCodeInsightFixture4TestCase() {
         assertTrue(text!!.contains("void"))
         assertTrue(text.contains("doSomething"))
         assertTrue(text.contains("()"))
+        assertTrue(text.contains("This is the method documentation."))
+    }
+
+    @Test
+    fun testGenerateDocForClassBasedExample() {
+        myFixture.configureByFile("example.d")
+
+        val myCodeClass = myFixture.findElementByText("MyCode", DLanguageClassDeclaration::class.java)
+
+        // put the caret on the doSomething() function in the source file
+        myFixture.editor.caretModel.moveToOffset(myCodeClass!!.identifier!!.startOffset)
+        val docElement = DocumentationManager.getInstance(project)
+            .findTargetElement(myFixture.editor, myFixture.file)
+        val text = provider!!.generateDoc(docElement, null)
+        assertNotNull(text)
+
+        assertTrue(text!!.contains("This is the CLASS documentation"))
     }
 }

--- a/src/test/resources/gold/documentation/example.d
+++ b/src/test/resources/gold/documentation/example.d
@@ -1,5 +1,11 @@
+/**
+  * This is the CLASS documentation
+  */
 class MyCode {
 
+    /**
+      * This is the method documentation.
+      */
     public static void doSomething() {}
 
     private void somethingElse() {}


### PR DESCRIPTION
This is a regression from the big PSI refactoring, now that the PSI is more simple, the logic for the documentation too. Also added a test to ensure this kind of regression won’t happen anymore.

Closes #1040 