### PR TITLE
Fix include names and always include DlangProjectGenerator

### DIFF
--- a/dlang/plugin-impl/src/main/resources/META-INF/clion-only.xml
+++ b/dlang/plugin-impl/src/main/resources/META-INF/clion-only.xml
@@ -1,7 +1,6 @@
 <idea-plugin>
 
     <extensions defaultExtensionNs="com.intellij">
-        <directoryProjectGenerator implementation="io.github.intellij.dlanguage.project.DlangProjectGenerator"/>
     </extensions>
 
 </idea-plugin>

--- a/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
+++ b/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
@@ -116,6 +116,7 @@
         <moduleType id="DLANGUAGE_MODULE" implementationClass="io.github.intellij.dlanguage.module.DlangModuleType"/>
 
 
+        <directoryProjectGenerator implementation="io.github.intellij.dlanguage.project.DlangProjectGenerator"/>
 
         <configurationType implementation="io.github.intellij.dlanguage.run.DlangRunDmdConfigurationType"/>
         <programRunner implementation="io.github.intellij.dlanguage.run.DmdBuildRunner"/>


### PR DESCRIPTION
This will allow to be able to create project for others IDE than Intellij and clion

Without this change the D application does not appear in clion. It does not affect intellij that don’t consider the DirectoryProcessors.