### PR TITLE
fix(#488): add a test for a nested static struct member usage

### DIFF
--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
@@ -152,6 +152,9 @@ class DResolveTest : DResolveTestCase() {
     fun testNestedStructDefinitionReferenceFullyQualifiedShouldNotResolveATopLevelStruct() = doTest(false)
 
     @Test
+    fun testNestedStructMemberUsageShouldResolve() = doTest()
+
+    @Test
     fun testLocalTypeDefinitionWithUsageAfterDefinitionShouldResolve() = doTest()
     @Test
     fun testLocalTypeDefinitionWithUsageBeforeDefinitionShouldNotResolve() = doTest(false)

--- a/src/test/resources/gold/resolve/nestedStructMemberUsageShouldResolve/a.d
+++ b/src/test/resources/gold/resolve/nestedStructMemberUsageShouldResolve/a.d
@@ -1,0 +1,7 @@
+module a;
+
+struct A {
+    static struct B {
+        int <resolved>x;
+    }
+}

--- a/src/test/resources/gold/resolve/nestedStructMemberUsageShouldResolve/b.d
+++ b/src/test/resources/gold/resolve/nestedStructMemberUsageShouldResolve/b.d
@@ -1,0 +1,7 @@
+module b;
+
+import a;
+
+int f(A.B b) {
+	return b.<ref>x;
+}


### PR DESCRIPTION
This was actually fixed since the resolve refactoring and type support
Closes #488 