### PR TITLE
Add support for platform version 251 (2025.1)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idea: [ '2024.2', '2024.2.2', '2024.3' ]
+        idea: [ '2024.3', '2025.1' ]
         jdk: [ '21' ]
         #os: [ubuntu-latest, windows-latest, macOS-latest]
 

--- a/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
+++ b/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
     <change-notes><![CDATA[
         <b>1.36</b> (<a href="https://github.com/intellij-dlanguage/intellij-dlanguage/milestone/61?closed=1">changelist</a>)<br/>
         <ul>
-            <li>Supports IntelliJ IDEA 2024.2 - 2024.3.*</li>
+            <li>Supports IntelliJ IDEA 2024.3 - 2025.1.*</li>
             <li>bug fixes</li>
         </ul>
     ]]>

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,17 +13,18 @@
 # 2024.1    (241.14494.240) bundled with Kotlin stdlib 1.9.22
 # 2024.2    (242.20224.300) bundled with Kotlin stdlib 1.9.24 (Uses Java 21 runtime)
 # 2024.3    (243.21565.193) bundled with Kotlin stdlib 2.0.21
+# 2025.1    (251.xxxxx.xxx) bundled with Kotlin stdlin 2.1.10
 
 pluginVersion = 1.36.4
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-ideaVersion = 2024.2
+ideaVersion = 2024.3
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 242
-pluginUntilBuild = 243.*
+pluginSinceBuild = 243
+pluginUntilBuild = 251.*
 
-psiViewerVersion = 242.4697
+psiViewerVersion = 243.7768
 
 # set via CI
 publishChannels=


### PR DESCRIPTION
Minumun platform requirements bump to 2024.3 for 2 reasons:
UI PR that will require this minimum version for API
be able to upgrade kotlin 2