### PR TITLE
Fix intellij 2025.1 tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,13 +92,10 @@ tasks.clean {
 
 dependencies {
     implementation (project(":utils"))
-    implementation (project(":errorreporting"))
     implementation (project(":debugger"))
-    implementation (project(":sdlang"))
     implementation (project(":dlang:psi-impl"))
-    testImplementation (project(":dlang:plugin-impl"))
 
-    implementation (libs.gson) // used by dub parser
+    testImplementation (project(":dlang:plugin-impl"))
 
     testImplementation (libs.mockito.kotlin)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,7 @@ dependencies {
             "org.intellij.intelliLang",
             "com.intellij.copyright"
         )
+        testFramework(TestFrameworkType.Platform)
         testFramework(TestFrameworkType.Plugin.Java)
     }
 }

--- a/dub/build.gradle.kts
+++ b/dub/build.gradle.kts
@@ -16,11 +16,13 @@ repositories {
 
 dependencies {
     api(project(":"))
+    api(project(":dlang:psi-api"))
     implementation(project(":utils"))
-    implementation(project(":errorreporting"))
-    implementation(project(":dlang:psi-api"))
+
     testImplementation(project(":"))
     testImplementation(project(":dlang:plugin-impl"))
+
+    implementation (libs.gson) // used by dub parser
 
     testImplementation (libs.junit.engine)
     testRuntimeOnly (libs.junit.engine)


### PR DESCRIPTION
optimize dependencies in modules, and fix the test by adding explicit dependency to platform tests