### PR TITLE
Fix highlighting of certains elements

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/annotator/DHighlightingAnnotator.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/annotator/DHighlightingAnnotator.kt
@@ -119,6 +119,7 @@ class DHighlightingAnnotator : Annotator {
             is TemplateThisParameter -> element.templateTypeParameter?.identifier
             is ReferenceExpression -> element.identifier
             is TemplateSingleArgument -> element.identifier
+            is QualifiedIdentifier -> element.identifier
             else -> element
         }
 


### PR DESCRIPTION
some non basic types (like string) are actually an alias. But we colored them like keywords because they are so essentials(basics). This manual coloration was wrongly applied so the whole type was colorized and not only the "basic type".

**Before:**
![image](https://github.com/user-attachments/assets/f62199a7-bd38-4ae1-b50f-0aa2ea1a3154)

**After:**
![image](https://github.com/user-attachments/assets/8c97d43a-ba10-48a6-bd12-caa0dc97cf55)

