### PR TITLE
Don’t report 0xff as empty hexadecimal integer value

### DIFF
--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/annotator/DlangLiteralChecker.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/annotator/DlangLiteralChecker.kt
@@ -10,7 +10,7 @@ fun checkLiteral(expressionElement: LiteralExpression, holder: AnnotationHolder)
     if (expressionElement.integeR_LITERAL != null) {
         val element = expressionElement.integeR_LITERAL!!
         val text = element.text
-        if (DPsiLiteralUtil.isHexadecimal(text) && !text.substring(2).contains("[0-9A-F]".toRegex()))
+        if (DPsiLiteralUtil.isHexadecimal(text) && !text.substring(2).contains("[0-9a-fA-F]".toRegex()))
             holder.newAnnotation(HighlightSeverity.ERROR, DlangBundle.message("literal.hexadecimal.no.digits")).range(element).create()
         else if (DPsiLiteralUtil.isBinary(text) && !text.substring(2).contains("[01]".toRegex()))
             holder.newAnnotation(HighlightSeverity.ERROR, DlangBundle.message("literal.binary.no.digits")).range(element).create()

--- a/src/test/resources/gold/highlighting/annotator/invalid_literal_values.d
+++ b/src/test/resources/gold/highlighting/annotator/invalid_literal_values.d
@@ -5,6 +5,7 @@ int i = <error descr="Value too large">99999999999999999999999999999999999999999
 
 // valid values
 int i = 0xFF;
+int i = 0xff;
 int i = 0;
 int i = 0b1;
 


### PR DESCRIPTION
A missing casing in the check made that `0xbb` literal was incorrectly reported as empty hexadecimal integer