### PR TITLE
Fix the condition for onModify of dub binary path

### DIFF
--- a/dub/src/main/kotlin/io/github/intellij/dub/project/settings/DubConfigurableProvider.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/project/settings/DubConfigurableProvider.kt
@@ -91,7 +91,10 @@ class DubConfigurablePanel() : ImprovedDisposable {
             ToolKey.DUB_KEY.path = executablePath.text
         }
         onIsModified {
-            executablePath.text != ToolKey.DUB_KEY.path
+            if (ToolKey.DUB_KEY.path == null)
+                !executablePath.text.isNullOrEmpty()
+            else
+                executablePath.text != ToolKey.DUB_KEY.path
         }
         update()
     }


### PR DESCRIPTION
When no binary is selected DUB_KEY.path is null but the executablePath.text is never null, it is at minimum the empty string. This fix make the modification behavior correct when autodetection is used (empty path provided) on not defined path configured (autodetection).