### PR TITLE
Fix a potential exception in ddoc generator

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/features/documentation/DDocGenerator.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/features/documentation/DDocGenerator.kt
@@ -274,8 +274,8 @@ class DDocGenerator {
             rawTextBuilder.append(txt)
         }
         val rawText = rawTextBuilder.toString()
-        val codeSnippet = rawText.substring(rawText.indexOf("\n"))
-        val rawLanguage = rawText.substring(0, rawText.indexOf("\n")).trim()
+        val rawLanguage = rawText.substringBefore("\n", missingDelimiterValue = "").trim()
+        val codeSnippet = rawText.substringAfter("\n", missingDelimiterValue = rawText)
         val language =  if (rawLanguage.isNotEmpty()) Language.findLanguageByID(rawLanguage)?: DLanguage else DLanguage
         return QuickDocHighlightingHelper.getStyledCodeBlock(element.project, language, codeSnippet )
     }

--- a/src/test/kotlin/io/github/intellij/dlanguage/features/DDocumentationProviderTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/features/DDocumentationProviderTest.kt
@@ -134,4 +134,26 @@ class DDocumentationProviderTest : LightPlatformCodeInsightFixture4TestCase() {
 
         assertTrue(text!!.contains("This is the CLASS documentation"))
     }
+
+
+    @Test
+    fun testGenerateDocWithEmptyCodeSnippet() {
+        myFixture.configureByText("example.d", """
+            /**
+             Contains empty code snippet
+             ~~~ ~~~*/
+             class I {}
+        """.trimIndent())
+
+        val myCodeClass = myFixture.findElementByText("I", DLanguageClassDeclaration::class.java)
+
+        // put the caret on the doSomething() function in the source file
+        myFixture.editor.caretModel.moveToOffset(myCodeClass!!.identifier!!.startOffset)
+        val docElement = DocumentationManager.getInstance(project)
+            .findTargetElement(myFixture.editor, myFixture.file)
+        val text = provider!!.generateDoc(docElement, null)
+        assertNotNull(text)
+
+        assertTrue(text!!.contains("Contains empty code snippet"))
+    }
 }


### PR DESCRIPTION
indexOf returns -1 when it do not find occurence of the requested string, so substring with -1 as index throws an exception.
Replacing it with a safe kotlin method to prevent it