### PR TITLE
Improve import resolution

### DIFF
--- a/dlang/psi-api/src/main/java/io/github/intellij/dlanguage/psi/DlangVisitor.java
+++ b/dlang/psi-api/src/main/java/io/github/intellij/dlanguage/psi/DlangVisitor.java
@@ -511,9 +511,9 @@ public class DlangVisitor extends PsiElementVisitor {
         visitPsiElement(o);
     }
 
-//    public void visitModule(@NotNull DLanguageModule o) {
-//        visitPsiElement(o);
-//    }
+    public void visitModule(@NotNull DLanguageModule o) {
+        visitPsiElement(o);
+    }
 
     public void visitModuleDeclaration(@NotNull final DLanguageModuleDeclaration o) {
         visitPsiElement(o);

--- a/dlang/psi-api/src/main/java/io/github/intellij/dlanguage/psi/DlangVisitor.java
+++ b/dlang/psi-api/src/main/java/io/github/intellij/dlanguage/psi/DlangVisitor.java
@@ -555,6 +555,10 @@ public class DlangVisitor extends PsiElementVisitor {
         visitPsiElement(o);
     }
 
+    public void visitPackage(@NotNull final DLanguagePackage o) {
+        visitPsiElement(o);
+    }
+
     public void visitParameter(@NotNull final DLanguageParameter o) {
         visitPsiElement(o);
     }

--- a/dlang/psi-api/src/main/java/io/github/intellij/dlanguage/psi/named/DLanguageModule.java
+++ b/dlang/psi-api/src/main/java/io/github/intellij/dlanguage/psi/named/DLanguageModule.java
@@ -1,0 +1,43 @@
+package io.github.intellij.dlanguage.psi.named;
+
+import com.intellij.navigation.NavigationItem;
+import com.intellij.openapi.util.NlsSafe;
+import com.intellij.psi.PsiCheckedRenameElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiQualifiedNamedElement;
+import com.intellij.psi.search.GlobalSearchScope;
+import io.github.intellij.dlanguage.psi.interfaces.DNamedElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents a Dlang package.
+ */
+public interface DLanguageModule extends DNamedElement, PsiCheckedRenameElement, NavigationItem,
+    PsiQualifiedNamedElement {
+
+    DLanguageModule[] EMPTY_ARRAY = new DLanguageModule[0];
+
+    @Override
+    @NotNull
+    @NlsSafe
+    String getQualifiedName();
+
+    /**
+     * Returns the parent of the package.
+     *
+     * @return the parent package, or null for no package.
+     */
+    @Nullable
+    DLanguagePackage getParentPackage();
+
+    /**
+     * Returns the file that represents the module.
+     */
+    PsiFile getFile(@NotNull GlobalSearchScope searchScope);
+
+    @Override
+    @NotNull
+    @NlsSafe
+    String getName();
+}

--- a/dlang/psi-api/src/main/java/io/github/intellij/dlanguage/psi/named/DLanguagePackage.java
+++ b/dlang/psi-api/src/main/java/io/github/intellij/dlanguage/psi/named/DLanguagePackage.java
@@ -1,0 +1,67 @@
+package io.github.intellij.dlanguage.psi.named;
+
+import com.intellij.navigation.NavigationItem;
+import com.intellij.openapi.util.NlsSafe;
+import com.intellij.psi.PsiCheckedRenameElement;
+import com.intellij.psi.PsiDirectoryContainer;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiQualifiedNamedElement;
+import com.intellij.psi.search.GlobalSearchScope;
+import io.github.intellij.dlanguage.psi.interfaces.DNamedElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents a Dlang package.
+ */
+public interface DLanguagePackage extends DNamedElement, PsiCheckedRenameElement, NavigationItem,
+    PsiDirectoryContainer, PsiQualifiedNamedElement {
+
+    DLanguagePackage[] EMPTY_ARRAY = new DLanguagePackage[0];
+
+    @Override
+    @NotNull
+    @NlsSafe
+    String getQualifiedName();
+
+    /**
+     * Returns the parent of the package.
+     *
+     * @return the parent package, or null for no package.
+     */
+    @Nullable
+    DLanguagePackage getParentPackage();
+
+    /**
+     * Return the list of subpackages of this package under all source roots of the project.
+     *
+     * @return the array of subpackages.
+     */
+    DLanguagePackage[] getSubPackages();
+
+    /**
+     * Return the list of subpackages of this package in the specified search scope.
+     *
+     * @param scope the scope in which packages are searches.
+     * @return the array of subpackages.
+     */
+    DLanguagePackage[] getSubPackages(@NotNull GlobalSearchScope scope);
+
+    /**
+     *
+     */
+    PsiFile @NotNull [] getFiles(@NotNull GlobalSearchScope searchScope);
+
+    /**
+     * This method must be invoked on the packege after all directories corresponding
+     * to it have been renamed/moved accordingly to the qualified name change.
+     *
+     * @param newQualifiedName the new qualified name of the package.
+     */
+    void handleQualifiedNameChange(@NotNull String newQualifiedName);
+
+    @Override
+    @NotNull
+    @NlsSafe
+    String getName();
+}

--- a/dlang/psi-api/src/main/kotlin/io/github/intellij/dlanguage/psi/interfaces/DVisibility.kt
+++ b/dlang/psi-api/src/main/kotlin/io/github/intellij/dlanguage/psi/interfaces/DVisibility.kt
@@ -41,5 +41,4 @@ val DVisibility.stubKind: DVisibilityStubKind
                 DVisibilityStubKind.PACKAGE_SPECIFIC
             DVisibilityStubKind.PACKAGE
         }
-        else -> error("Unsupported visibility")
     }

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/ext/DLanguageQualifiedIdentifierImplMixin.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/ext/DLanguageQualifiedIdentifierImplMixin.kt
@@ -29,7 +29,7 @@ abstract class DLanguageQualifiedIdentifierImplMixin(node: ASTNode) : ASTWrapper
         else {
             return null
         }
-        if (PsiTreeUtil.getParentOfType<AliasInitializer>(this, AliasInitializer::class.java, true, Declaration::class.java, Parameter::class.java) != null) {
+        if (PsiTreeUtil.getParentOfType(this, AliasInitializer::class.java, true, Declaration::class.java, Parameter::class.java) != null) {
             return AliasValueReference(this, range, qualifiedIdentifier, referenceElement.text)
         }
         val inTypeSuffix = PsiTreeUtil.getParentOfType<TypeSuffix>(this, TypeSuffix::class.java, true, Declaration::class.java, Parameter::class.java) != null

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/impl/DLanguageImportDeclarationImpl.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/impl/DLanguageImportDeclarationImpl.kt
@@ -38,24 +38,23 @@ class DLanguageImportDeclarationImpl : DStubBasedPsiElementBase<DLanguageImportD
         }
     }
 
-    override fun getKW_IMPORT(): PsiElement? {
-        return findChildByType<PsiElement?>(DlangTypes.KW_IMPORT)
-    }
+    override fun getKW_STATIC(): PsiElement? =
+        findChildByType(DlangTypes.KW_STATIC)
 
-    override fun getSingleImports(): MutableList<DLanguageSingleImport> {
-        return PsiTreeUtil.getChildrenOfTypeAsList<DLanguageSingleImport>(this, DLanguageSingleImport::class.java)
-    }
+    override fun getKW_IMPORT(): PsiElement? =
+        findChildByType(DlangTypes.KW_IMPORT)
 
-    override fun getImportBindings(): DLanguageImportBindings? {
-        return PsiTreeUtil.getChildOfType<DLanguageImportBindings?>(this, DLanguageImportBindings::class.java)
-    }
+    override fun getSingleImports(): List<DLanguageSingleImport> =
+        PsiTreeUtil.getChildrenOfTypeAsList(this, DLanguageSingleImport::class.java)
 
-    override fun getOP_COMMAs(): MutableList<PsiElement?> {
-        return findChildrenByType<PsiElement?>(DlangTypes.OP_COMMA)
-    }
+    override fun getImportBindings(): DLanguageImportBindings? =
+        PsiTreeUtil.getChildOfType(this, DLanguageImportBindings::class.java)
+
+    override fun getOP_COMMAs(): List<PsiElement?> =
+        findChildrenByType(DlangTypes.OP_COMMA)
 
     override fun getOP_SCOLON(): PsiElement? {
-        return findChildByType<PsiElement?>(DlangTypes.OP_SCOLON)
+        return findChildByType(DlangTypes.OP_SCOLON)
     }
 
     override fun visibility(): DVisibility {

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/impl/DLanguageModuleImpl.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/impl/DLanguageModuleImpl.kt
@@ -1,0 +1,214 @@
+package io.github.intellij.dlanguage.psi.impl
+
+import com.intellij.icons.AllIcons
+import com.intellij.lang.ASTNode
+import com.intellij.lang.Language
+import com.intellij.navigation.ItemPresentation
+import com.intellij.navigation.ItemPresentationProviders
+import com.intellij.openapi.ui.Queryable
+import com.intellij.openapi.util.NlsSafe
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.*
+import com.intellij.psi.impl.PsiElementBase
+import com.intellij.psi.scope.PsiScopeProcessor
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.ui.IconManager
+import com.intellij.util.IncorrectOperationException
+import io.github.intellij.dlanguage.DLanguage
+import io.github.intellij.dlanguage.psi.DlangPsiFile
+import io.github.intellij.dlanguage.psi.DlangVisitor
+import io.github.intellij.dlanguage.psi.named.DLanguageModule
+import io.github.intellij.dlanguage.psi.named.DLanguagePackage
+import io.github.intellij.dlanguage.resolve.processors.parameters.DAttributes
+import io.github.intellij.dlanguage.resolve.processors.parameters.DAttributesFinder
+import javax.swing.Icon
+
+class DLanguageModuleImpl(private val manager: PsiManager, private val file: DlangPsiFile) : PsiElementBase(),
+    DLanguageModule, Queryable {
+
+    private fun findPackage(qName: String): DLanguagePackage? {
+        return null
+    }
+
+    private fun allScope(): GlobalSearchScope =
+        TODO("Not yet implemented")
+
+
+    override fun getQualifiedName(): @NlsSafe String = file.getFullyQualifiedModuleName()
+
+    override fun getParentPackage(): DLanguagePackage? =
+        findPackage(StringUtil.getPackageName(qualifiedName))
+
+    override fun getFile(searchScope: GlobalSearchScope): PsiFile = file
+
+    override fun getName(): String = file.getModuleName()
+
+    override fun getAttributes(): DAttributes? = null
+
+    override fun isPublic(): Boolean = true
+
+    override fun isProtected(): Boolean = false
+
+    override fun isPrivate(): Boolean = false
+
+    override fun visibility(): DAttributesFinder.Visibility = DAttributesFinder.Visibility.PUBLIC
+
+    override fun isProperty(): Boolean = false
+
+    override fun isNoGC(): Boolean = false
+
+    override fun isExtern(): Boolean = false
+
+    override fun isPure(): Boolean = false
+
+    override fun isNothrow(): Boolean = false
+
+    override fun isConst(): Boolean = false
+
+    override fun isImmutable(): Boolean = false
+
+    override fun isEnum(): Boolean = false
+
+    override fun setName(name: @NlsSafe String): PsiElement? {
+        return DLanguageModuleImpl(manager, file.setName(name) as DlangPsiFile)
+    }
+
+    override fun checkSetName(name: String?) {
+    }
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is DlangVisitor)
+            visitor.visitModule(this)
+        else
+            visitor.visitElement(this)
+    }
+
+    override fun getElementIcon(flags: Int): Icon {
+        return IconManager.getInstance().createLayeredIcon(this, AllIcons.Nodes.Package, flags)
+    }
+
+    override fun getPresentation(): ItemPresentation? {
+        return ItemPresentationProviders.getItemPresentation(this)
+    }
+
+    override fun navigate(requestFocus: Boolean) {
+        file.navigate(requestFocus)
+    }
+
+    override fun getLanguage(): Language = DLanguage
+
+    override fun getChildren(): Array<out PsiElement> = EMPTY_ARRAY
+
+    override fun getParent(): PsiElement? = parentPackage
+
+    override fun getContainingFile(): PsiFile? = null
+
+    override fun getTextRange(): TextRange? = null
+
+    override fun getStartOffsetInParent(): Int = -1
+
+    override fun getTextLength(): Int = -1
+
+    override fun findElementAt(offset: Int): PsiElement? = null
+
+    override fun getTextOffset(): Int = -1
+
+    override fun getText(): @NlsSafe String? = null
+
+    override fun textToCharArray(): CharArray {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getNode(): ASTNode? = null
+
+    override fun textMatches(text: CharSequence): Boolean {
+        throw IncorrectOperationException()
+    }
+
+    override fun textMatches(element: PsiElement): Boolean {
+        throw IncorrectOperationException()
+    }
+
+    override fun copy(): PsiElement? = null
+
+    override fun add(element: PsiElement): PsiElement {
+        throw IncorrectOperationException()
+    }
+
+    override fun addBefore(element: PsiElement, anchor: PsiElement?): PsiElement {
+        throw IncorrectOperationException()
+    }
+
+    override fun addAfter(element: PsiElement, anchor: PsiElement?): PsiElement {
+        throw IncorrectOperationException()
+    }
+
+    override fun checkAdd(element: PsiElement) {
+        throw IncorrectOperationException()
+    }
+
+    override fun delete() {
+        checkDelete()
+        file.delete()
+    }
+
+    override fun checkDelete() {
+        file.checkDelete()
+    }
+
+    override fun replace(newElement: PsiElement): PsiElement {
+        throw IncorrectOperationException()
+    }
+
+    override fun isWritable(): Boolean {
+        return file.isWritable
+    }
+
+    override fun toString(): String = "DLanguagePackage:$qualifiedName"
+
+    override fun isValid(): Boolean = file.isValid
+
+    override fun canNavigate(): Boolean = isValid
+
+    override fun canNavigateToSource(): Boolean = false
+
+    override fun isPhysical(): Boolean = true
+
+    override fun putInfo(info: MutableMap<in String, in String>) {
+        info["packageName"] = name
+        info["packageQualifiedName"] = qualifiedName
+    }
+
+    override fun getManager(): PsiManager = manager
+
+    override fun clone(): Any {
+        return super.clone()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return other is DLanguageModuleImpl
+            && manager == other.manager
+            && qualifiedName == other.qualifiedName
+    }
+
+    override fun isEquivalentTo(another: PsiElement?): Boolean {
+        if (another is DlangPsiFile)
+            return file == another
+        return super.isEquivalentTo(another)
+    }
+
+    override fun hashCode(): Int = qualifiedName.hashCode()
+
+    override fun getNameIdentifier(): PsiElement? = null
+
+    override fun processDeclarations(
+        processor: PsiScopeProcessor,
+        state: ResolveState,
+        lastParent: PsiElement?,
+        place: PsiElement
+    ): Boolean {
+        return file.processDeclarations(processor, state, lastParent, place)
+    }
+
+}

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/impl/DLanguagePackageImpl.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/impl/DLanguagePackageImpl.kt
@@ -1,0 +1,255 @@
+package io.github.intellij.dlanguage.psi.impl
+
+import com.intellij.icons.AllIcons
+import com.intellij.ide.util.PsiNavigationSupport
+import com.intellij.lang.ASTNode
+import com.intellij.lang.Language
+import com.intellij.navigation.ItemPresentation
+import com.intellij.navigation.ItemPresentationProviders
+import com.intellij.openapi.roots.impl.DirectoryIndex
+import com.intellij.openapi.ui.Queryable
+import com.intellij.openapi.util.NlsSafe
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.*
+import com.intellij.psi.impl.PsiElementBase
+import com.intellij.psi.impl.file.PsiDirectoryFactory
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiUtilCore
+import com.intellij.ui.IconManager
+import com.intellij.util.IncorrectOperationException
+import io.github.intellij.dlanguage.DLanguage
+import io.github.intellij.dlanguage.psi.DlangVisitor
+import io.github.intellij.dlanguage.psi.named.DLanguagePackage
+import io.github.intellij.dlanguage.resolve.processors.parameters.DAttributes
+import io.github.intellij.dlanguage.resolve.processors.parameters.DAttributesFinder
+import javax.swing.Icon
+
+class DLanguagePackageImpl(private val manager: PsiManager, private val qualifiedName: String) : PsiElementBase(), DLanguagePackage, Queryable {
+
+    private fun findPackage(qName: String): DLanguagePackage? {
+        return null
+    }
+
+    private fun allScope(): GlobalSearchScope =
+        TODO("Not yet implemented")
+
+
+    override fun getQualifiedName(): @NlsSafe String = qualifiedName
+
+    override fun getParentPackage(): DLanguagePackage? =
+        findPackage(StringUtil.getPackageName(qualifiedName))
+
+    override fun getSubPackages(): Array<out DLanguagePackage?>? =
+        getSubPackages(allScope())
+
+    override fun getSubPackages(scope: GlobalSearchScope): Array<out DLanguagePackage?>? =
+        TODO("Not yet implemented")
+
+    override fun getFiles(searchScope: GlobalSearchScope): Array<out PsiFile?> {
+        TODO("Not yet implemented")
+    }
+
+    override fun handleQualifiedNameChange(newQualifiedName: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDirectories(): Array<out PsiDirectory> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDirectories(p0: GlobalSearchScope): Array<out PsiDirectory> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getName(): String {
+        val index = qualifiedName.lastIndexOf(".")
+        return if (index <= 0)
+            qualifiedName
+        else
+            qualifiedName.substring(index + 1)
+    }
+
+    override fun getAttributes(): DAttributes? = null
+
+    override fun isPublic(): Boolean = true
+
+    override fun isProtected(): Boolean = false
+
+    override fun isPrivate(): Boolean = false
+
+    override fun visibility(): DAttributesFinder.Visibility = DAttributesFinder.Visibility.PUBLIC
+
+    override fun isProperty(): Boolean = false
+
+    override fun isNoGC(): Boolean = false
+
+    override fun isExtern(): Boolean = false
+
+    override fun isPure(): Boolean = false
+
+    override fun isNothrow(): Boolean = false
+
+    override fun isConst(): Boolean = false
+
+    override fun isImmutable(): Boolean = false
+
+    override fun isEnum(): Boolean = false
+
+    override fun setName(name: @NlsSafe String): PsiElement? {
+        checkSetName(name)
+        for (dir in directories) {
+            dir.setName(name)
+        }
+        val nameAfterRename = PsiUtilCore.getQualifiedNameAfterRename(qualifiedName, name)
+        return findPackage(nameAfterRename)
+    }
+
+    override fun checkSetName(name: String?) {
+        for (dir in directories) {
+            dir.checkSetName(name)
+        }
+    }
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is DlangVisitor)
+            visitor.visitPackage(this)
+        else
+            visitor.visitElement(this)
+    }
+
+    override fun getElementIcon(flags: Int): Icon {
+        return IconManager.getInstance().createLayeredIcon(this, AllIcons.Nodes.Package, flags)
+    }
+
+    override fun getPresentation(): ItemPresentation? {
+        return ItemPresentationProviders.getItemPresentation(this)
+    }
+
+    override fun navigate(requestFocus: Boolean) {
+        val directories = DirectoryIndex.getInstance(project)
+                .getDirectoriesByPackageName(qualifiedName, true)
+                .map { PsiDirectoryFactory.getInstance(project).createDirectory(it) }
+                .toSet()
+        if (directories.size != 1)
+            return
+        return PsiNavigationSupport.getInstance().navigateToDirectory(directories.first(), requestFocus)
+    }
+
+    override fun getLanguage(): Language = DLanguage
+
+    override fun getChildren(): Array<out PsiElement> = EMPTY_ARRAY
+
+    override fun getParent(): PsiElement? = parentPackage
+
+    override fun getContainingFile(): PsiFile? = null
+
+    override fun getTextRange(): TextRange? = null
+
+    override fun getStartOffsetInParent(): Int = -1
+
+    override fun getTextLength(): Int = -1
+
+    override fun findElementAt(offset: Int): PsiElement? = null
+
+    override fun getTextOffset(): Int = -1
+
+    override fun getText(): @NlsSafe String? = null
+
+    override fun textToCharArray(): CharArray {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getNode(): ASTNode? = null
+
+    override fun textMatches(text: CharSequence): Boolean {
+        throw IncorrectOperationException()
+    }
+
+    override fun textMatches(element: PsiElement): Boolean {
+        throw IncorrectOperationException()
+    }
+
+    override fun copy(): PsiElement? = null
+
+    override fun add(element: PsiElement): PsiElement {
+        throw IncorrectOperationException()
+    }
+
+    override fun addBefore(element: PsiElement, anchor: PsiElement?): PsiElement {
+        throw IncorrectOperationException()
+    }
+
+    override fun addAfter(element: PsiElement, anchor: PsiElement?): PsiElement {
+        throw IncorrectOperationException()
+    }
+
+    override fun checkAdd(element: PsiElement) {
+        throw IncorrectOperationException()
+    }
+
+    override fun delete() {
+        checkDelete()
+        for (dir in directories) {
+            dir.delete()
+        }
+    }
+
+    override fun checkDelete() {
+       for (dir in directories) {
+           dir.checkDelete()
+       }
+    }
+
+    override fun replace(newElement: PsiElement): PsiElement {
+        throw IncorrectOperationException()
+    }
+
+    override fun isWritable(): Boolean {
+        val dirs = directories
+        for (dir in dirs) {
+            if(!dir.isWritable)
+                return false
+        }
+        return true
+    }
+
+    override fun toString(): String = "DLanguagePackage:$qualifiedName"
+
+    override fun isValid(): Boolean =
+        !project.isDisposed
+
+    override fun canNavigate(): Boolean = isValid
+
+    override fun canNavigateToSource(): Boolean = false
+
+    override fun isPhysical(): Boolean = true
+
+    override fun putInfo(info: MutableMap<in String, in String>) {
+        info["packageName"] = name
+        info["packageQualifiedName"] = qualifiedName
+    }
+
+    override fun getManager(): PsiManager = manager
+
+    override fun clone(): Any {
+        return super.clone()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return other is DLanguagePackageImpl
+            && manager == other.manager
+            && qualifiedName == other.qualifiedName
+    }
+
+    override fun isEquivalentTo(another: PsiElement?): Boolean {
+        if (another is PsiDirectory)
+            return name == another.name
+        return super.isEquivalentTo(another)
+    }
+
+    override fun hashCode(): Int = qualifiedName.hashCode()
+
+    override fun getNameIdentifier(): PsiElement? = null
+
+}

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/references/GenericExpressionElementReference.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/references/GenericExpressionElementReference.kt
@@ -27,7 +27,7 @@ class GenericExpressionElementReference(element: ReferenceExpression,
             PsiScopesUtil.resolveAndWalk(processor, this, null)
         }
         if (processor.getResult().size == 1) {
-            return processor.getResult()[0].element as DNamedElement
+            return processor.getResult().first().element as DNamedElement
         }
         return null
     }

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/resolve/processor/GenericProcessor.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/resolve/processor/GenericProcessor.kt
@@ -17,7 +17,7 @@ class GenericProcessor(private val elementName: String, private val startPlace: 
         if (element !is DNamedElement) return true
         if (element.name != elementName) return true
         candidates = SmartList()
-        (candidates as SmartList<DResolveResult>).add(DResolveResult(element))
+        candidates!!.add(DResolveResult(element))
         resolveResult = null
         return false
     }

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/resolve/processor/TypeProcessor.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/resolve/processor/TypeProcessor.kt
@@ -11,6 +11,8 @@ import io.github.intellij.dlanguage.psi.DResolveResult
 import io.github.intellij.dlanguage.psi.interfaces.DNamedElement
 import io.github.intellij.dlanguage.psi.interfaces.TemplateParameter
 import io.github.intellij.dlanguage.psi.interfaces.UserDefinedType
+import io.github.intellij.dlanguage.psi.named.DLanguageModule
+import io.github.intellij.dlanguage.psi.named.DLanguagePackage
 import io.github.intellij.dlanguage.utils.*
 
 class TypeProcessor(private val elementName: String,
@@ -24,7 +26,8 @@ class TypeProcessor(private val elementName: String,
     override fun execute(element: PsiElement, state: ResolveState): Boolean {
         if (element !is UserDefinedType && element !is DeclaratorIdentifier &&
             element !is AliasInitializer && element !is TemplateDeclaration &&
-            element !is TemplateParameter) {
+            element !is TemplateParameter && element !is DLanguageModule && element !is DLanguagePackage
+        ) {
             if (!(canSearchVariable && (element is Parameter || element is AutoAssignment || element is IdentifierInitializer)))
                 return true
         }

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/scope/PsiScopesUtil.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/scope/PsiScopesUtil.kt
@@ -61,11 +61,7 @@ object PsiScopesUtil {
         processor: PsiScopeProcessor,
         state: ResolveState,
     ): Boolean {
-        var child: PsiElement? =  thisElement.prevSibling
-
-        if (child == null) {
-            return true
-        }
+        var child: PsiElement? = thisElement.prevSibling ?: return true
 
         while (child != null) {
             // ignore attribute with block (example `public {}`) as they don’t impact us

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/scope/PsiScopesUtil.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/scope/PsiScopesUtil.kt
@@ -6,8 +6,12 @@ import com.intellij.psi.PsiQualifiedReference
 import com.intellij.psi.ResolveState
 import com.intellij.psi.scope.PsiScopeProcessor
 import io.github.intellij.dlanguage.psi.interfaces.Expression
+import io.github.intellij.dlanguage.psi.named.DLanguageModule
+import io.github.intellij.dlanguage.psi.named.DLanguagePackage
+import io.github.intellij.dlanguage.psi.scope.processor.PackageOrModuleProcessor
 import io.github.intellij.dlanguage.psi.scope.processor.UFCSProcessor
 import io.github.intellij.dlanguage.psi.types.*
+import io.github.intellij.dlanguage.resolve.IS_QUALIFIED_SYMBOL
 import io.github.intellij.dlanguage.utils.AttributeSpecifier
 
 object PsiScopesUtil {
@@ -90,7 +94,17 @@ object PsiScopesUtil {
             }
             if (type == null) {
                 val target: PsiElement? = reference.qualifier?.reference?.resolve()
-                val `continue` = target?.processDeclarations(processor, ResolveState.initial(), target, reference.element) ?: true
+                var state = ResolveState.initial()
+                if (target is DLanguagePackage) {
+                    // First try to resolve to a package or module (of imported symbol)
+                    val packageProcessor = PackageOrModuleProcessor(processor, target)
+                    if (!treeWalkUp(packageProcessor, reference.element, null))
+                        return false
+                }
+                if (target is DLanguagePackage || target is DLanguageModule) {
+                    state = state.put(IS_QUALIFIED_SYMBOL, true)
+                }
+                val `continue` = target?.processDeclarations(processor, state, target, reference.element) ?: true
                 if (!`continue`)
                     return false
             }
@@ -98,6 +112,11 @@ object PsiScopesUtil {
             val processor = UFCSProcessor(processor);
             return treeWalkUp(processor, reference.element, null);
         } else {
+            // First try to resolve to a package or module (of imported symbol)
+            val packageProcessor = PackageOrModuleProcessor(processor, null)
+            if(!treeWalkUp(packageProcessor, reference.element, null))
+                return false
+
             // simple expression -> resolve a top level declaration
             return treeWalkUp(processor, reference.element, maxScope)
         }

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/scope/processor/PackageOrModuleProcessor.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/scope/processor/PackageOrModuleProcessor.kt
@@ -1,0 +1,41 @@
+package io.github.intellij.dlanguage.psi.scope.processor
+
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiElement
+import com.intellij.psi.ResolveState
+import com.intellij.psi.scope.PsiScopeProcessor
+import io.github.intellij.dlanguage.psi.named.DLanguagePackage
+import io.github.intellij.dlanguage.psi.scope.ElementDeclarationHint
+import io.github.intellij.dlanguage.utils.ImportDeclaration
+import io.github.intellij.dlanguage.utils.getImportText
+
+class PackageOrModuleProcessor(private val delegate: PsiScopeProcessor, private val parentPackage: DLanguagePackage?) : PsiScopeProcessor, ElementDeclarationHint {
+
+    override fun execute(element: PsiElement, state: ResolveState): Boolean {
+        if (element is ImportDeclaration) {
+            val packages = element.singleImports.filter { it.identifier == null }.mapNotNull{
+                var id = it.identifierChain ?: return@mapNotNull null
+                while(id.identifierChain != null && (parentPackage == null || getImportText(id.identifierChain!!) != parentPackage.qualifiedName))
+                    id = id.identifierChain!!
+                id
+            }.toList()
+            for (`package` in packages) {
+                val resolvedPackage = `package`.reference?.resolve() ?:continue
+                if (!delegate.execute(resolvedPackage, state))
+                    return false
+            }
+        }
+        return true
+    }
+
+    override fun shouldProcess(kind: ElementDeclarationHint.DeclarationKind): Boolean {
+        return kind != ElementDeclarationHint.DeclarationKind.IMPORT
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any?> getHint(hintKey: Key<T?>): T? {
+        if (hintKey == ElementDeclarationHint.KEY)
+            return this as T
+        return super.getHint(hintKey)
+    }
+}

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/resolve/DResolveUtil.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/resolve/DResolveUtil.kt
@@ -48,3 +48,4 @@ object DResolveUtil {
 }
 
 val PROCESSED_FILES_KEY = Key.create<MutableList<String>>("PROCESSED_FILES")
+val IS_QUALIFIED_SYMBOL = Key.create<Boolean>("IS_QUALIFIED_SYMBOL")

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/resolve/ScopeProcessorImpl.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/resolve/ScopeProcessorImpl.kt
@@ -566,8 +566,15 @@ object ScopeProcessorImpl {
                             state: ResolveState,
                             lastParent: PsiElement?,
                             place: PsiElement): Boolean {
+        if (!processor.execute(element, state))
+            return false
         val hint = processor.getHint(ElementDeclarationHint.KEY)
         if (hint != null && !hint.shouldProcess(ElementDeclarationHint.DeclarationKind.IMPORT)) {
+            return true
+        }
+
+        val canProcessStatic = state.get(IS_QUALIFIED_SYMBOL)?:false
+        if (element.kW_STATIC != null && !canProcessStatic) {
             return true
         }
 

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/resolve/ScopeProcessorImpl.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/resolve/ScopeProcessorImpl.kt
@@ -586,9 +586,8 @@ object ScopeProcessorImpl {
         // we have an import binding, search for it first
         if (element.importBindings != null) {
             // with import binding restricts the scope of the corresponding single import
-            val base = singleImports.removeLastOrNull() // remove the last as due to binding, we can only access to his bindings
-            if (base == null)
-                return true
+            val base = singleImports.removeLastOrNull()
+                ?: return true // remove the last as due to binding, we can only access to his bindings
             for (elt in element.importBindings!!.importBinds) {
                 if (elt.namedImportBind != null) {
                     if (!processor.execute(elt.namedImportBind!!, state))

--- a/scripts/types_regen_script.d
+++ b/scripts/types_regen_script.d
@@ -231,7 +231,7 @@ static this() {
     types_children["ImportBind"] = ["Identifier","NamedImportBind"];
     types_mixins["ImportBind"] = "DLanguageImportBindImplMixin";
     types_children["ImportBindings"] = ["OP_COMMA*","ImportBind*","SingleImport","OP_COLON"];
-    stub_children["ImportDeclaration"] = ["KW_IMPORT","SingleImport*","ImportBindings","OP_COMMA*","OP_SCOLON"];
+    stub_children["ImportDeclaration"] = ["KW_STATIC","KW_IMPORT","SingleImport*","ImportBindings","OP_COMMA*","OP_SCOLON"];
     types_extra_interfaces["ImportDeclaration"] = ["Statement", "Declaration", "DVisibilityModifier"];
     types_children["ImportExpression"] = ["ImportExpression","AssignExpression","OP_PAR_RIGHT","OP_PAR_LEFT"];
     types_mixins["ImportExpression"] = "DLanguageImportExpressionImplMixin";

--- a/src/test/kotlin/io/github/intellij/dlanguage/DLightPlatformCodeInsightFixtureTestCase.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/DLightPlatformCodeInsightFixtureTestCase.kt
@@ -1,8 +1,5 @@
 package io.github.intellij.dlanguage
 
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.projectRoots.ProjectJdkTable
-import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.CharsetToolkit
@@ -82,13 +79,5 @@ abstract class DLightPlatformCodeInsightFixtureTestCase(
         var text = FileUtil.loadFile(File(resource), CharsetToolkit.UTF8).trim { it <= ' ' }
         text = StringUtil.convertLineSeparators(text)
         return text
-    }
-
-    protected fun setUpProjectSdk() {
-        ApplicationManager.getApplication().runWriteAction {
-            val sdk = projectDescriptor.sdk
-            ProjectJdkTable.getInstance().addJdk(sdk!!)
-            ProjectRootManager.getInstance(myFixture.project).projectSdk = sdk
-        }
     }
 }

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
@@ -6,10 +6,11 @@ import com.intellij.openapi.vfs.VirtualFileFilter
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.psi.impl.PsiManagerEx
+import com.intellij.psi.search.GlobalSearchScope
 import io.github.intellij.dlanguage.DLightPlatformCodeInsightFixtureTestCase
-import io.github.intellij.dlanguage.psi.DlangPsiFileImpl
 import io.github.intellij.dlanguage.psi.named.DLanguageConstructor
 import io.github.intellij.dlanguage.psi.named.DLanguageFunctionDeclaration
+import io.github.intellij.dlanguage.psi.named.DLanguageModule
 import org.intellij.lang.annotations.Language
 import java.io.File
 
@@ -125,8 +126,8 @@ abstract class DResolveTestCase : DLightPlatformCodeInsightFixtureTestCase("reso
         val element = referencedElement!!.resolve()
         if (resolvedFileName != null) {
             assertNotNull("Referenced not resolved", element)
-            assertInstanceOf(element!!, DlangPsiFileImpl::class.java)
-            assertEquals((element as DlangPsiFileImpl).name, resolvedFileName)
+            assertInstanceOf(element!!, DLanguageModule::class.java)
+            assertEquals((element as DLanguageModule).getFile(GlobalSearchScope.EMPTY_SCOPE).name, resolvedFileName)
         } else {
             assertNull(element)
         }

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTestCase.kt
@@ -11,7 +11,6 @@ import io.github.intellij.dlanguage.psi.DlangPsiFileImpl
 import io.github.intellij.dlanguage.psi.named.DLanguageConstructor
 import io.github.intellij.dlanguage.psi.named.DLanguageFunctionDeclaration
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.assertNotEquals
 import java.io.File
 
 abstract class DResolveTestCase : DLightPlatformCodeInsightFixtureTestCase("resolve", "resolve") {
@@ -27,52 +26,50 @@ abstract class DResolveTestCase : DLightPlatformCodeInsightFixtureTestCase("reso
         super.setUp()
     }
 
-    private fun prepareFilesFindReferences() {
-        for (file in testDataFiles) {
+    private fun prepareFilesFindReferences(files: Array<File>) {
+        for (file in files) {
             var text = FileUtil.loadFile(file, Charsets.UTF_8)
             text = StringUtil.convertLineSeparators(text)
-            val refIndexBefore = text.indexOf("<ref>")
-            val resolvedIndexBefore = text.indexOf("<resolved>")
-            val referencedOffset: Int
-            val resolvedOffset: Int
-            if (refIndexBefore >= 0 && resolvedIndexBefore >= 0 && refIndexBefore < resolvedIndexBefore) {
-                referencedOffset = text.indexOf("<ref>")
-                text = text.replace("<ref>", "")
-                resolvedOffset = text.indexOf("<resolved>")
-                text = text.replace("<resolved>", "")
-            } else {
-                resolvedOffset = text.indexOf("<resolved>")
-                text = text.replace("<resolved>", "")
-                referencedOffset = text.indexOf("<ref>")
-                text = text.replace("<ref>", "")
-            }
-            val psiFile = myFixture.configureByText(file.name, text)
-            if (referencedOffset != -1) {
-                referencedElement = psiFile.findReferenceAt(referencedOffset)!!
-            }
-            if (resolvedOffset != -1) {
-                resolvedElement = psiFile.findElementAt(resolvedOffset)!!.parent
-            }
+            prepareFileFindReferences("<ref>", "<resolved>", text, file.name)
         }
     }
 
-    private fun doCheck(succeed: Boolean) {
+    protected fun prepareFileFindReferences(refName: String, resolvedName: String, fileText: String, fileName: String) {
+        var text = fileText
+        val refIndexBefore = text.indexOf(refName)
+        val resolvedIndexBefore = text.indexOf(resolvedName)
+        val referencedOffset: Int
+        val resolvedOffset: Int
+        if (refIndexBefore >= 0 && resolvedIndexBefore >= 0 && refIndexBefore < resolvedIndexBefore) {
+            referencedOffset = text.indexOf(refName)
+            text = text.replace(refName, "")
+            resolvedOffset = text.indexOf(resolvedName)
+            text = text.replace(resolvedName, "")
+        } else {
+            resolvedOffset = text.indexOf(resolvedName)
+            text = text.replace(resolvedName, "")
+            referencedOffset = text.indexOf(refName)
+            text = text.replace(refName, "")
+        }
+        val psiFile = myFixture.configureByText(fileName, text)
+        if (referencedOffset != -1) {
+            referencedElement = psiFile.findReferenceAt(referencedOffset)!!
+        }
+        if (resolvedOffset != -1) {
+            resolvedElement = psiFile.findElementAt(resolvedOffset)!!.parent
+        }
+    }
+
+    protected fun doCheck(succeed: Boolean, refName: String = "<ref>", resolvedName: String = "<resolved>" ) {
         if (succeed && referencedElement == null) {
-            fail("Could not find reference at caret.")
+            fail("Reference not found, ensure `${refName}` is in the file.")
         }
         if (succeed && resolvedElement == null) {
-            fail("Could not find resolved element.")
+            fail("Resolved not found, ensure `${resolvedName}` is in the file.")
         }
         if (succeed) {
             val element = referencedElement!!.resolve()
-            //function,class,constructor
-            /*if (resolvedElement instanceof DlangInterfaceOrClass ) {
-                assertEquals("Could not resolve expected reference.", resolvedElement, referencedElement.resolve().getParent());
-            }*/
-            /* else if (resolvedElement instanceof DLanguageConstructor) {
-                assertTrue(referencedElement.resolve() instanceof DLanguageConstructor);
-            }*/
-            /*else*/if (resolvedElement is DLanguageConstructor) {
+            if (resolvedElement is DLanguageConstructor) {
                 assertEquals("Could not resolve expected reference.", resolvedElement, element)
             } else if (super.getTestName(true) == "scopedImportsMembers") {
                 assertNotNull("Could not resolve expected reference.", element)
@@ -92,36 +89,16 @@ abstract class DResolveTestCase : DLightPlatformCodeInsightFixtureTestCase("reso
     }
 
     protected fun doTest(succeed: Boolean = true) {
-        prepareFilesFindReferences()
+        prepareFilesFindReferences(testDataFiles)
         doCheck(succeed)
     }
 
     protected fun doCheckByText1(@Language("D") mainFileContent: String,
                                  succeed: Boolean = true) {
-        var text = mainFileContent
         val referenceIndicator = "/*<ref>*/"
         val resolvedIndicator = "/*<resolved>*/"
-        val refIndexBefore = mainFileContent.indexOf(referenceIndicator)
-        val resolvedIndexBefore = mainFileContent.indexOf(resolvedIndicator)
-        val referencedOffset: Int
-        val resolvedOffset: Int
-        assertNotEquals("Reference not found, ensure /*ref*/ is in the file", -1, refIndexBefore)
-        assertNotEquals("Resolved not found, ensure /*resolved*/ is in the file", -1, resolvedIndexBefore)
-        if (refIndexBefore < resolvedIndexBefore) {
-            referencedOffset = text.indexOf(referenceIndicator)
-            text = text.replace(referenceIndicator, "")
-            resolvedOffset = text.indexOf(resolvedIndicator)
-            text = text.replace(resolvedIndicator, "")
-        } else {
-            resolvedOffset = text.indexOf(resolvedIndicator)
-            text = text.replace(resolvedIndicator, "")
-            referencedOffset = text.indexOf(referenceIndicator)
-            text = text.replace(referenceIndicator, "")
-        }
-        val psiFile = myFixture.configureByText("main.d", text)
-        referencedElement = psiFile.findReferenceAt(referencedOffset)
-        resolvedElement = psiFile.findElementAt(resolvedOffset)!!.parent
-        doCheck(succeed)
+        prepareFileFindReferences(referenceIndicator,  resolvedIndicator, mainFileContent, "main.d")
+        doCheck(succeed, referenceIndicator, resolvedIndicator)
     }
 
     protected fun doCheckByText2(@Language("D") mainFileContent: String,
@@ -129,14 +106,8 @@ abstract class DResolveTestCase : DLightPlatformCodeInsightFixtureTestCase("reso
                                  succeed: Boolean = true) {
         val referenceIndicator = "/*<ref>*/"
         val resolvedIndicator = "/*<resolved>*/"
-        val referencedOffset = mainFileContent.indexOf(referenceIndicator)
-        val mainFileText = mainFileContent.replace(referenceIndicator, "")
-        val resolvedOffset = file2.indexOf(resolvedIndicator)
-        val file2Text = file2.replace(resolvedIndicator, "")
-        val psiFile2 = myFixture.configureByText("file2.d", file2Text)
-        val psiFile = myFixture.configureByText("main.d", mainFileText)
-        referencedElement = psiFile.findReferenceAt(referencedOffset)
-        resolvedElement = psiFile2.findElementAt(resolvedOffset)!!.parent
+        prepareFileFindReferences(referenceIndicator,  resolvedIndicator, mainFileContent, "main.d")
+        prepareFileFindReferences(referenceIndicator,  resolvedIndicator, file2, "file2.d")
         doCheck(succeed)
     }
 

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DScopedImportResolveTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DScopedImportResolveTest.kt
@@ -1,0 +1,114 @@
+package io.github.intellij.dlanguage.resolve
+
+import org.junit.Test
+
+/**
+ * Test import cases for scoped import.
+ *
+ * Test cases taken from specs: https://dlang.org/spec/module.html#scoped_imports
+ */
+class DScopedImportResolveTest : DResolveTestCase() {
+
+    override fun getTestDataPath(): String = ""
+
+    @Test
+    fun test1() = doCheckByText2("""
+        void main()
+        {
+            void /*<resolved>*/writeln(string) {}
+            void foo()
+            {
+                /*<ref>*/writeln("bar");
+                import std.stdio;
+                void writeln(string) {}
+            }
+        }
+    """.trimIndent(),
+        """
+            module std.stdio;
+
+                void write(string a){}
+                void writeln(string a){}
+        """.trimIndent())
+
+    @Test
+    fun test2() = doCheckByText2("""
+        void main()
+        {
+            void writeln(string) {}
+            void foo()
+            {
+                import std.stdio;
+                /*<ref>*/writeln("bar");
+                void writeln(string) {}
+            }
+        }
+    """.trimIndent(),
+        """
+            module std.stdio;
+
+                void write(string a){}
+                void /*<resolved>*/writeln(string a){}
+        """.trimIndent())
+
+    @Test
+    fun test3() = doCheckByText2("""
+        void main()
+        {
+            void writeln(string) {}
+            void foo()
+            {
+                import std.stdio;
+                void /*<resolved>*/writeln(string) {}
+                /*<ref>*/writeln("bar");
+            }
+        }
+    """.trimIndent(),
+        """
+            module std.stdio;
+
+                void write(string a){}
+                void writeln(string a){}
+        """.trimIndent())
+
+    @Test
+    fun test4() = doCheckByText2("""
+        void main()
+        {
+            void /*<resolved>*/writeln(string) {}
+            void foo()
+            {
+                import std.stdio;
+                void writeln(string) {}
+            }
+            /*<ref>*/writeln("bar");
+        }
+    """.trimIndent(),
+        """
+            module std.stdio;
+
+                void write(string a){}
+                void writeln(string a){}
+        """.trimIndent())
+
+    @Test
+    fun test5() = doCheckByText2("""
+        void main()
+        {
+            void writeln(string) {}
+            void foo()
+            {
+                import std.stdio;
+                void writeln(string) {}
+            }
+            std.stdio./*<ref>*/writeln("bar");
+        }
+    """.trimIndent(),
+        """
+            module std.stdio;
+
+                void write(string a){}
+                void writeln(string a){}
+        """.trimIndent(),
+        false)
+}

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DSymbolNameLookupResolveTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DSymbolNameLookupResolveTest.kt
@@ -1,0 +1,218 @@
+package io.github.intellij.dlanguage.resolve
+
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+
+/**
+ * Test resolution algorithm fom symbol when there is import "conflict".
+ *
+ * Test case are taken from specs: https://dlang.org/spec/module.html#name_lookup
+ */
+class DSymbolNameLookupResolveTest : DResolveTestCase() {
+
+    override fun getTestDataPath(): String = ""
+
+    private fun doCheckByText3(@Language("D") main: String,
+                               @Language("D") second: String,
+                               @Language("D") third: String,
+                               succeed: Boolean = true) {
+        val referenceIndicator = "/*<ref>*/"
+        val resolvedIndicator = "/*<resolved>*/"
+        prepareFileFindReferences(referenceIndicator,  resolvedIndicator, main, "main.d")
+        prepareFileFindReferences(referenceIndicator,  resolvedIndicator, second, "file2.d")
+        prepareFileFindReferences(referenceIndicator,  resolvedIndicator, third, "file3.d")
+        doCheck(succeed)
+    }
+
+    @Test
+    fun `test C module foo case`() = doCheckByText2("""
+                module A;
+                void foo();
+                void bar();
+            """.trimIndent(),
+            """
+                module C;
+                import A;
+                void /*<resolved>*/foo();
+                void test()
+                {
+                    /*<ref>*/foo(); // C.foo() is called
+                }
+            """.trimIndent())
+
+    @Test
+    fun `test C module bar case`() = doCheckByText2("""
+                module A;
+                void foo();
+                void /*<resolved>*/bar();
+            """.trimIndent(),
+        """
+                module C;
+                import A;
+                void foo();
+                void test()
+                {
+                    /*<ref>*/bar(); // A.bar() is called
+                }
+            """.trimIndent())
+
+    /* TODO enable once fixed.
+        Needs to properly implement the lookup algorithm for that : https://dlang.org/spec/module.html#name_lookup
+    @Test
+    fun `test D module foo case`() = doCheckByText3("""
+                module A;
+                void foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module B;
+                void foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module D;
+                import A;
+                import B;
+                void test()
+                {
+                    /*<ref>*/foo(); // error, A.foo() or B.foo() ?
+                }
+            """.trimIndent(),
+        false)*/
+
+    @Test
+    fun `test D module A_foo case`() = doCheckByText3("""
+                module A;
+                void /*<resolved>*/foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module B;
+                void foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module D;
+                import A;
+                import B;
+                void test()
+                {
+                    A./*<ref>*/foo(); // A.foo() is called
+                }
+            """.trimIndent())
+
+    @Test
+    fun `test D module B_foo case`() = doCheckByText3("""
+                module A;
+                void foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module B;
+                void /*<resolved>*/foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module D;
+                import A;
+                import B;
+                void test()
+                {
+                    B./*<ref>*/foo(); // B.foo() is called
+                }
+            """.trimIndent())
+
+    @Test
+    fun `test E module foo case`() = doCheckByText3("""
+                module A;
+                void foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module B;
+                void foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module E;
+                import A;
+                import B;
+                alias /*<resolved>*/foo = B.foo;
+                void test()
+                {
+                    /*<ref>*/foo(); // call B.foo()
+                }
+            """.trimIndent())
+
+    @Test
+    fun `test E module A_foo case`() = doCheckByText3("""
+                module A;
+                void /*<resolved>*/foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module B;
+                void foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module E;
+                import A;
+                import B;
+                alias foo = B.foo;
+                void test()
+                {
+                    A./*<ref>*/foo(); // A.foo() is called
+                }
+            """.trimIndent())
+
+    @Test
+    fun `test E module B_foo case`() = doCheckByText3("""
+                module A;
+                void foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module B;
+                void foo();
+                void bar();
+            """.trimIndent(),
+        """
+                module E;
+                import A;
+                import B;
+                alias /*<resolved>*/foo = B.foo;
+                void test()
+                {
+                    /*<ref>*/foo(); // B.foo() is called
+                }
+            """.trimIndent())
+
+    // Note: this test is not technically in the spec files, but it is here to validate the resolve algorithm
+    // AKA: if a package (of imported module) as the same as a symbol, then it resolve to the package and not to the symbol
+    // The test ensure that we don’t resolve the symbol (it is not as simple to check that it resolve correctly to the package,
+    // but this case is already covered by other tests)
+    @Test
+    fun `test package resolving has priority over symbol`() = doCheckByText3(
+        """
+            module principal;
+
+            void main() {
+                import std.stdio;
+                import a;
+
+                /*<ref>*/std;
+            }
+        """.trimIndent(),
+        """
+            module std.stdio;
+
+            void writeln();
+        """.trimIndent(),
+        """
+            module a;
+            void /*<resolved>*/std();
+        """.trimIndent(),
+        succeed = false)
+}


### PR DESCRIPTION
Correctly resolve symbol imported with static import
Properly resolve symbols called by there fully qualified name

With this change the resolve algorithm of imported symbol is almost fully compliant with specs. Only one case is not correctly supported (see commented test for this), but this case is an "error" case (when there is a conflict due to 2 imports)