### PR TITLE
Fix some exception in the lexer when reaching eof

### DIFF
--- a/dlang/psi-impl/src/main/jflex/io/github/intellij/dlanguage/lexer/DLanguageLexer.flex
+++ b/dlang/psi-impl/src/main/jflex/io/github/intellij/dlanguage/lexer/DLanguageLexer.flex
@@ -399,7 +399,6 @@ NESTING_BLOCK_DOC_END = "+/"
 
     <<EOF>>     {
           if (stringDelimiterClosed) {
-              yypushback(1);
               yybegin(YYINITIAL);
               return DELIMITED_STRING;
           }
@@ -433,7 +432,6 @@ NESTING_BLOCK_DOC_END = "+/"
 
     <<EOF>>     {
           if (stringDelimiterClosed) {
-              yypushback(1);
               yybegin(YYINITIAL);
               return DELIMITED_STRING;
           }

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/lexer/DlangLexer.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/lexer/DlangLexer.kt
@@ -100,8 +100,10 @@ class DlangLexer : LexerBase() {
                 flexLocateToken()
             }
         }
-        if (myBuffer[myTokenEnd] == 'c' || myBuffer[myTokenEnd] == 'w' || myBuffer[myTokenEnd] == 'd') {
-            myTokenEnd += 1
+        if (myTokenEnd < myBufferEnd) {
+            if (myBuffer[myTokenEnd] == 'c' || myBuffer[myTokenEnd] == 'w' || myBuffer[myTokenEnd] == 'd') {
+                myTokenEnd += 1
+            }
         }
         myTokenStart = myTokenStringIndexStart
         myTokenType = DlangTypes.TOKEN_STRING

--- a/src/test/kotlin/io/github/intellij/dlanguage/lexer/DlangLexerTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/lexer/DlangLexerTest.kt
@@ -132,6 +132,8 @@ class DlangLexerTest : DlangLexerTestBase("lexer") {
     fun teststring_delim_invalid_non_ending() = doTest("q\"/test\"d;", """
 BAD_CHARACTER ('q"/test"d;')
 """)
+    fun teststring_delim_unterminated() = doTest("q\"test\"", "DlangTokenType.DELIMITED_STRING ('q\"test\"')")
+    fun teststring_token_no_extension() = doTest("q{test}", "DlangTokenType.TOKEN_STRING ('q{test}')")
 
 
     // tokens


### PR DESCRIPTION
you can’t yypushback on eof as eof do not progress.
before the fix, the lexer crashed and the file could not be displayed