### PR TITLE
Ensure that element privately imported in object module are not checked

### DIFF
--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/DlangPsiFileImpl.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/DlangPsiFileImpl.kt
@@ -129,7 +129,7 @@ class DlangPsiFileImpl(viewProvider: FileViewProvider) : PsiFileBase(viewProvide
                 objects = objects.filter {it.containingDirectory.name == "dmd" }.toSet()
 
             val objectModule = objects.firstOrNull()?.containingFile as DlangPsiFile?
-            toContinue = objectModule?.processDeclarations(processor, newState, objectModule, objectModule) != false
+            toContinue = objectModule?.processDeclarations(processor, newState, lastParent, place) != false
         }
         processor.handleEvent(PsiScopeProcessor.Event.SET_DECLARATION_HOLDER, null)
         return toContinue

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
@@ -265,4 +265,7 @@ class DResolveTest : DResolveTestCase() {
 
     @Test
     fun testFunctionCallUFCSWithLocalSelectiveImportResolve() = doTest()
+
+    @Test
+    fun testFunctionCallUFCSWithoutImportShouldNotResolve() = doTest(false)
 }

--- a/src/test/resources/gold/resolve/functionCallUFCSWithoutImportShouldNotResolve/object.d
+++ b/src/test/resources/gold/resolve/functionCallUFCSWithoutImportShouldNotResolve/object.d
@@ -1,0 +1,1 @@
+import resolve;

--- a/src/test/resources/gold/resolve/functionCallUFCSWithoutImportShouldNotResolve/resolve.d
+++ b/src/test/resources/gold/resolve/functionCallUFCSWithoutImportShouldNotResolve/resolve.d
@@ -1,0 +1,3 @@
+module resolve;
+
+void writeln(int i) {}

--- a/src/test/resources/gold/resolve/functionCallUFCSWithoutImportShouldNotResolve/usage.d
+++ b/src/test/resources/gold/resolve/functionCallUFCSWithoutImportShouldNotResolve/usage.d
@@ -1,0 +1,4 @@
+
+void foo() {
+    <ref>writeln(3);
+}


### PR DESCRIPTION
When looking at object, previously a wrong argument allowed the algorithm to think that the element was in the object module and so allowing to search in imported modules from object. This resulted in resolved element while they should not.