### PR TITLE
More reslove fixes

### DIFF
--- a/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
+++ b/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,7 @@
         <ul>
             <li>Supports IntelliJ IDEA 2025.1 - 2025.2.*</li>
             <li>Improve UI on intellij when creating a project</li>
+            <li>Better resolution of symbols<li>
             <li>Bug fixes</li>
         </ul>
     ]]>

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/scope/PsiScopesUtil.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/scope/PsiScopesUtil.kt
@@ -50,7 +50,7 @@ object PsiScopesUtil {
         }
 
         while (child != null) {
-            if (!child.processDeclarations(processor, state, null, place)) return false
+            if (!child.processDeclarations(processor, state, lastParent, place)) return false
             child = child.prevSibling
         }
 

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/scope/processor/UFCSProcessor.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/psi/scope/processor/UFCSProcessor.kt
@@ -4,10 +4,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.scope.PsiScopeProcessor
 import io.github.intellij.dlanguage.psi.DlangPsiFile
-import io.github.intellij.dlanguage.utils.FunctionDeclaration
-import io.github.intellij.dlanguage.utils.ImportBind
-import io.github.intellij.dlanguage.utils.ImportDeclaration
-import io.github.intellij.dlanguage.utils.NamedImportBind
+import io.github.intellij.dlanguage.utils.*
 
 class UFCSProcessor(private val delegate: PsiScopeProcessor) : PsiScopeProcessor {
     private var isCurrentModuleEval: Boolean = false
@@ -15,7 +12,9 @@ class UFCSProcessor(private val delegate: PsiScopeProcessor) : PsiScopeProcessor
     override fun execute(element: PsiElement, state: ResolveState): Boolean {
         if (element is ImportDeclaration || element is ImportBind || element is NamedImportBind)
             return delegate.execute(element, state)
-        if (isCurrentModuleEval && element is FunctionDeclaration) {
+        if (isCurrentModuleEval &&
+            (element is FunctionDeclaration ||
+                element is TemplateDeclaration)) {
             return delegate.execute(element, state)
         }
         return true

--- a/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/resolve/ScopeProcessorImpl.kt
+++ b/dlang/psi-impl/src/main/kotlin/io/github/intellij/dlanguage/resolve/ScopeProcessorImpl.kt
@@ -892,7 +892,34 @@ object ScopeProcessorImpl {
                             state: ResolveState,
                             lastParent: PsiElement?,
                             place: PsiElement): Boolean {
+        // Maybe change Psi structure to separate staticIF and version(Foo) forms into 2 different nodes
         var toContinue = true
+
+        // `version(FOO):` form
+        if (element.kW_ELSE == null && element.oP_COLON != null) {
+            // Our member cannot see other declarations
+            for (decl in element.declarations) {
+                // don’t process declaration twice, we just processed it
+                if (lastParent != null && lastParent === decl) {
+                    continue
+                }
+                if (!decl.processDeclarations(processor, state, lastParent, place)) {
+                    toContinue = false
+                }
+            }
+            for (block in element.declarationBlocks) {
+                // don’t process declaration twice, we just processed it
+                if (lastParent != null && lastParent === block) {
+                    continue
+                }
+                if (!block.processDeclarations(processor, state, lastParent, place)) {
+                    toContinue = false
+                }
+            }
+            return toContinue
+        }
+
+        // Static If
         // Our member cannot see other declarations
         if (lastParent != null && lastParent.parent === element) {
             return true

--- a/scripts/types_regen_script.d
+++ b/scripts/types_regen_script.d
@@ -417,7 +417,7 @@ static this() {
     types_extra_interfaces["VersionCondition"] = ["Declaration"];
     types_children["WhileStatement"] = ["KW_WHILE","IfCondition","Statement","OP_PAR_RIGHT","OP_PAR_LEFT"];
     types_extra_interfaces["WhileStatement"] = ["Statement"];
-    types_children["WithStatement"] = ["KW_WITH","AssignExpression*","OP_COMMA*","OP_PAR_RIGHT","OP_PAR_LEFT","LabeledStatement","BlockStatement","IfStatement","WhileStatement","DoStatement","ForStatement","ForeachStatement","SwitchStatement","FinalSwitchStatement","ContinueStatement","BreakStatement","ReturnStatement","GotoStatement","WithStatement","SynchronizedStatement","TryStatement","ScopeGuardStatement","PragmaStatement","AsmStatement","DebugSpecification", "ConditionalStatement", "VersionSpecification","StaticAssertStatement","ExpressionStatement"];
+    types_children["WithStatement"] = ["KW_WITH","OP_PAR_LEFT","Expression","OP_PAR_RIGHT","Statement"];
     types_extra_interfaces["WithStatement"] = ["Statement"];
     types_children["XorExpression"] = ["Expression*", "OP_XOR"];
     types_extra_interfaces["XorExpression"] = ["BitwiseExpression"];
@@ -617,7 +617,7 @@ static this() {
     has_processDeclaration["VersionCondition"] = false;
     has_processDeclaration["VersionSpecification"] = true;
     has_processDeclaration["WhileStatement"] = true;
-    has_processDeclaration["WithStatement"] = false;
+    has_processDeclaration["WithStatement"] = true;
     has_processDeclaration["XorExpression"] = false;
 }
 

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
@@ -225,6 +225,9 @@ class DResolveTest : DResolveTestCase() {
     fun testVariableInCaseDefaultStatement() = doTest()
 
     @Test
+    fun testWithStatementShouldResolveInnerElements() = doTest()
+
+    @Test
     fun testReferenceInVariableDeclarationMustNotResolveToVariableDeclarationItself() = doTest()
 
     @Test

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
@@ -172,6 +172,9 @@ class DResolveTest : DResolveTestCase() {
     fun testEnumUsageWithoutEnumTypePrefixShouldNotResolve() = doTest(false)
 
     @Test
+    fun testEnumUsageWithoutEnumTypePrefixShouldNotResolve2() = doTest(false)
+
+    @Test
     fun testEnumValueQualifiedAsTypeShouldNotResolve() = doTest(false)
 
     @Test

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
@@ -288,5 +288,8 @@ class DResolveTest : DResolveTestCase() {
     fun testFunctionCallUFCSWithLocalSelectiveImportResolve() = doTest()
 
     @Test
+    fun testFunctionCallUFCSWithLocalSelectiveImportResolve2() = doTest()
+
+    @Test
     fun testFunctionCallUFCSWithoutImportShouldNotResolve() = doTest(false)
 }

--- a/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/resolve/DResolveTest.kt
@@ -89,6 +89,8 @@ class DResolveTest : DResolveTestCase() {
 
     @Test
     fun testAliasValueWithSameNameAsAliasDeclarationShouldNotResolveToAliasDeclaration2() = doTest(false)
+    @Test
+    fun testAliasValueWithSameNameAsAliasDeclarationShouldNotResolveToAliasDeclaration3() = doTest(false)
 
     @Test
     fun testScopedImportsFail() = doTest(false)
@@ -298,4 +300,7 @@ class DResolveTest : DResolveTestCase() {
 
     @Test
     fun testFunctionCallUFCSWithoutImportShouldNotResolve() = doTest(false)
+
+    @Test
+    fun functionDeclarationInSameConditionalDeclarationBlockAsUsageShouldResolve() = doTest()
 }

--- a/src/test/resources/gold/resolve/aliasValueWithSameNameAsAliasDeclarationShouldNotResolveToAliasDeclaration3/usage.d
+++ b/src/test/resources/gold/resolve/aliasValueWithSameNameAsAliasDeclarationShouldNotResolveToAliasDeclaration3/usage.d
@@ -1,0 +1,9 @@
+module crash_alias;
+
+template Bar(T) {
+    static if (false) {
+        alias Foo = <ref>Foo!int;
+    } else {
+        alias Foo = <ref>Foo!string;
+    }
+}

--- a/src/test/resources/gold/resolve/enumUsageWithoutEnumTypePrefixShouldNotResolve2/usage.d
+++ b/src/test/resources/gold/resolve/enumUsageWithoutEnumTypePrefixShouldNotResolve2/usage.d
@@ -1,0 +1,10 @@
+module usage;
+
+void main() {
+    enum E {
+        A,
+        X,
+    }
+    
+    foo(<ref>X);
+}

--- a/src/test/resources/gold/resolve/functionCallUFCSWithLocalSelectiveImportResolve2/other.d
+++ b/src/test/resources/gold/resolve/functionCallUFCSWithLocalSelectiveImportResolve2/other.d
@@ -1,0 +1,3 @@
+module other;
+
+template <resolved>writeln(int i) {}

--- a/src/test/resources/gold/resolve/functionCallUFCSWithLocalSelectiveImportResolve2/resolve.d
+++ b/src/test/resources/gold/resolve/functionCallUFCSWithLocalSelectiveImportResolve2/resolve.d
@@ -1,0 +1,4 @@
+void foo() {
+    import other : writeln;
+    3.<ref>writeln;
+}

--- a/src/test/resources/gold/resolve/functionDeclarationInSameConditionalDeclarationBlockAsUsageShouldResolve/usage.d
+++ b/src/test/resources/gold/resolve/functionDeclarationInSameConditionalDeclarationBlockAsUsageShouldResolve/usage.d
@@ -1,0 +1,7 @@
+
+version(None):
+void foo() {
+    <ref>bar();
+}
+
+void <resolved>bar() {}

--- a/src/test/resources/gold/resolve/withStatementShouldResolveInnerElements/usage.d
+++ b/src/test/resources/gold/resolve/withStatementShouldResolveInnerElements/usage.d
@@ -1,0 +1,13 @@
+
+enum E { <resolved>A, B};
+
+void foo() {
+    E e;
+    
+    with (e) {
+        switch (e) {
+            case <ref>A:
+            break;
+        }
+    }
+}


### PR DESCRIPTION
Properly handle WithStatements
Fix resolve of second form of ConditionalCompilation (`version(Foo):`)
Add test to ensure named enum values are not accidentally resolved
Fix UFCS search when target is a template