### PR TITLE
Fix delimited string checks and highligting

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/lexer/DDelimitedStringDelimiterLexer.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/lexer/DDelimitedStringDelimiterLexer.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.tree.IElementType
 import io.github.intellij.dlanguage.psi.DlangTypes.DELIMITED_STRING
 import io.github.intellij.dlanguage.utils.getCorrespondingClosingDelimiter
 import io.github.intellij.dlanguage.utils.getOpeningDelimiter
+import io.github.intellij.dlanguage.utils.isPredefinedDelimiter
 
 /**
  * Lex the string to highlight the Delimiter in the delimitedString
@@ -93,6 +94,15 @@ class DDelimitedStringDelimiterLexer : LexerBase() {
     private fun locateEndingToken(start: Int): Int {
         val delimiter = getCorrespondingClosingDelimiter(openingDelimiter!!)
         state = 3
-        return start + bufferSequence.subSequence(start, bufferEnd).split(delimiter)[0].length
+
+        // for this case always the last one, lexer handle it (there can be some nesting of symbols)
+        if (delimiter != openingDelimiter)
+            return start + bufferSequence.subSequence(start, bufferEnd).lastIndexOf(delimiter)
+
+        if (isPredefinedDelimiter(delimiter))
+            return start + bufferSequence.subSequence(start, bufferEnd).split(delimiter)[0].length
+
+        // the delimiter is a user defined text
+        return start + bufferSequence.subSequence(start, bufferEnd).split("\n$delimiter")[0].length + 1 // +1 as we added the \n character
     }
 }

--- a/src/main/kotlin/io/github/intellij/dlanguage/utils/DStringUtil.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/utils/DStringUtil.kt
@@ -1,5 +1,6 @@
 package io.github.intellij.dlanguage.utils
 
+private val predefinedDelimiters = listOf('(', ')' , '[', ']', '{', '}', '<', '>', '/', '\\')
 
 /**
  * Take the opening delimiter of a String and return the corresponding closing one
@@ -14,12 +15,16 @@ fun getCorrespondingClosingDelimiter(openingDelimiter: String) : String {
     }
 }
 
+fun isPredefinedDelimiter(literal: String): Boolean {
+    return predefinedDelimiters.indexOf(literal[0]) != -1
+}
+
 /**
  * Take a Delimited String content without the surrounding delimiters (`q"` and `"`) and
  * return the opening delimiter, or null if the delimiter is invalid.
  */
 fun getOpeningDelimiter(literal: String) : String? {
-    if (listOf('(', ')' , '[', ']', '{', '}', '<', '>', '/', '\\').indexOf(literal[0]) != -1)
+    if (isPredefinedDelimiter(literal))
         return literal[0].toString()
 
     // Invalid delimiter

--- a/src/test/resources/gold/highlighting/annotator/invalid_string_delimiters.d
+++ b/src/test/resources/gold/highlighting/annotator/invalid_string_delimiters.d
@@ -7,3 +7,13 @@ enum a = <error descr="Invalid string delimiter">q"test"</error>;
 enum a = <error descr="Invalid string delimiter">q"ùtestù"</error>;
 enum a = q"/test/<error descr="Illegal text found after closing delimiter, expected \" character instead">foo/</error>";
 enum a = q"/test/<error descr="Illegal text found after closing delimiter, expected \" character instead">foo/</error>"d;
+
+auto a = q"TEST
+blah
+ TEST this one is valid as thereis a space before
+TEST<error descr="Illegal text found after closing delimiter, expected \" character instead">
+invalid text part of error
+TEST</error>";
+
+
+enum a = q"(foo(xxxx))"; // this is a legal string


### PR DESCRIPTION
Now the closing delimiter is always the correct one and the check for invalid text after closing delimiter is properly placed.

<img width="374" height="171" alt="image" src="https://github.com/user-attachments/assets/fa7748b0-1cc9-4368-9eb5-f2a054cfd856" />
