### PR TITLE
Fix(#1158): correctly detect valid delemited string

### DIFF
--- a/src/main/kotlin/io/github/intellij/dlanguage/annotator/DStringLiteralAnnotator.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/annotator/DStringLiteralAnnotator.kt
@@ -41,11 +41,11 @@ class DStringLiteralAnnotator : Annotator {
                     closingDelimiter = "\n$closingDelimiter"
 
                 val lines = value.split(closingDelimiter)
-                val expectedDelimitersCount = if (!isPredefinedDelimiter(openingDelimiter)) 1 else 2
+                val expectedDelimitersCount = if (isPredefinedDelimiter(openingDelimiter) && getCorrespondingClosingDelimiter(openingDelimiter) == openingDelimiter) 3 else 2
                 if (lines.size > expectedDelimitersCount) {
                     val elemStartIndex = elem.startOffset + 2 // + 2 to because we skipped q"
                     holder.newAnnotation(HighlightSeverity.ERROR, "Illegal text found after closing delimiter, expected \" character instead")
-                        .range(TextRange(elemStartIndex + StringUtils.ordinalIndexOf(value, closingDelimiter, expectedDelimitersCount) + closingDelimiter.length, elemStartIndex + value.length)).create()
+                        .range(TextRange(elemStartIndex + StringUtils.ordinalIndexOf(value, closingDelimiter, expectedDelimitersCount - 1) + closingDelimiter.length, elemStartIndex + value.length)).create()
                 }
             }
             return

--- a/src/test/resources/gold/highlighting/annotator/invalid_string_delimiters.d
+++ b/src/test/resources/gold/highlighting/annotator/invalid_string_delimiters.d
@@ -17,3 +17,10 @@ TEST</error>";
 
 
 enum a = q"(foo(xxxx))"; // this is a legal string
+enum a = q"HERE
+foo
+HERE"; // this is a legal string
+enum a = q"übel
+foo
+übel"; // this is a legal string
+enum a = q"/foo/"; // this is a legal string


### PR DESCRIPTION
The checker was incorrectly reporting the closing characted as error. It’s now properly handled and covered by a test.

Closes #1158 