### PR TITLE
[#1183,#1094] prepare 1.39 release (for 2025.3.*)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idea: [ '2025.1', '2025.2', '2025.2.4' ]
+        idea: [ '2025.3' ]
         jdk: [ '21' ]
         #os: [ubuntu-latest, windows-latest, macOS-latest]
 
@@ -22,6 +22,7 @@ jobs:
         distribution: temurin
         java-version: ${{ matrix.jdk }}
         cache: gradle
+
     - name: Install D compiler
       uses: dlang-community/setup-dlang@v2
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Support for the [D Programming Language](http://dlang.org/) within IntelliJ IDEA
 
 The primary focus for the project is to support Intellij IDEA (both IC and IU). Some work has been done to try and support CLion but it's not currently usable. It may work on other IDEs such as AppCode, Android Studio, PyCharm, etc but this is not tested by the dev team.
 
-We generally try to support the last years worth of IDE releases. The current build targets *Intellij 2025.1 - 2025.2.+*.
+We generally try to support the last years worth of IDE releases. The current build targets *Intellij 2025.3 - 2025.3.+*.
 
 For a list of older releases and their supported IDE versions see our [Compatibility Matrix](https://github.com/intellij-dlanguage/intellij-dlanguage/wiki/Compatibility-Matrix).
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,12 +103,12 @@ dependencies {
     testRuntimeOnly (libs.junit.engine)
 
     intellijPlatform {
-        intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
+        intellijIdea(providers.gradleProperty("ideaVersion").get())
+        bundledModule("intellij.platform.langInjection")
         bundledPlugins(
             "com.intellij.java",
             "com.intellij.java.ide",
             "com.intellij.modules.json",
-            "org.intellij.intelliLang",
             "com.intellij.copyright"
         )
         testFramework(TestFrameworkType.Platform)

--- a/debugger/build.gradle.kts
+++ b/debugger/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     testImplementation (libs.junit.engine)
     testRuntimeOnly (libs.junit.engine)
     intellijPlatform {
-        intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
+        intellijIdea(providers.gradleProperty("ideaVersion").get())
         testFramework(TestFrameworkType.Platform)
     }
 }

--- a/dlang/idea/build.gradle.kts
+++ b/dlang/idea/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     testRuntimeOnly (libs.junit.engine)
 
     intellijPlatform {
-        intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
+        intellijIdea(providers.gradleProperty("ideaVersion").get())
         bundledPlugins(
             "com.intellij.java",
             "com.intellij.java.ide"

--- a/dlang/plugin-impl/build.gradle.kts
+++ b/dlang/plugin-impl/build.gradle.kts
@@ -86,13 +86,13 @@ dependencies {
         pluginComposedModule(implementation (project(":dlang:idea")))
         pluginComposedModule(implementation (project(":dub:idea")))
 
-        intellijIdeaCommunity(properties("ideaVersion"))
+        intellijIdea(properties("ideaVersion"))
 
+        bundledModule("intellij.platform.langInjection")
         bundledPlugins(
             "com.intellij.java",
             "com.intellij.java.ide",
             "com.intellij.modules.json",
-            "org.intellij.intelliLang",
             "com.intellij.copyright"
         )
 

--- a/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
+++ b/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
@@ -19,12 +19,9 @@
     ]]></description>
 
     <change-notes><![CDATA[
-        <b>1.38</b> (<a href="https://github.com/intellij-dlanguage/intellij-dlanguage/milestone/70?closed=1">changelist</a>)<br/>
+        <b>1.39</b> (<a href="https://github.com/intellij-dlanguage/intellij-dlanguage/milestone/71?closed=1">changelist</a>)<br/>
         <ul>
-            <li>Supports IntelliJ IDEA 2025.1 - 2025.2.*</li>
-            <li>Improve UI on intellij when creating a project</li>
-            <li>Better resolution of symbols<li>
-            <li>Bug fixes</li>
+            <li>Supports IntelliJ IDEA 2025.3 - 2025.3.*</li>
         </ul>
     ]]>
     </change-notes>

--- a/dlang/psi-api/build.gradle.kts
+++ b/dlang/psi-api/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
     testRuntimeOnly (libs.junit.engine)
 
     intellijPlatform {
-        intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
+        intellijIdea(providers.gradleProperty("ideaVersion").get())
         testFramework(TestFrameworkType.Platform)
     }
 }

--- a/dlang/psi-impl/build.gradle.kts
+++ b/dlang/psi-impl/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     testRuntimeOnly (libs.junit.engine)
 
     intellijPlatform {
-        intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
+        intellijIdea(providers.gradleProperty("ideaVersion").get())
         testFramework(TestFrameworkType.Platform)
     }
 }

--- a/dub/build.gradle.kts
+++ b/dub/build.gradle.kts
@@ -28,12 +28,12 @@ dependencies {
     testRuntimeOnly (libs.junit.engine)
 
     intellijPlatform {
-        intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
+        intellijIdea(providers.gradleProperty("ideaVersion").get())
+        bundledModule("intellij.platform.langInjection")
         bundledPlugins(
             "com.intellij.java",
             "com.intellij.java.ide",
             "com.intellij.modules.json",
-            "org.intellij.intelliLang",
             "com.intellij.copyright"
         )
         testFramework(TestFrameworkType.Platform)

--- a/dub/idea/build.gradle.kts
+++ b/dub/idea/build.gradle.kts
@@ -26,12 +26,12 @@ dependencies {
     testRuntimeOnly (libs.junit.engine)
 
     intellijPlatform {
-        intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
+        intellijIdea(providers.gradleProperty("ideaVersion").get())
+        bundledModule("intellij.platform.langInjection")
         bundledPlugins(
             "com.intellij.java",
             "com.intellij.java.ide",
             "com.intellij.modules.json",
-            "org.intellij.intelliLang",
             "com.intellij.copyright"
         )
         testFramework(TestFrameworkType.Platform)

--- a/dub/src/main/kotlin/io/github/intellij/dub/project/DubProjectOpenProcessor.kt
+++ b/dub/src/main/kotlin/io/github/intellij/dub/project/DubProjectOpenProcessor.kt
@@ -51,7 +51,7 @@ class DubProjectOpenProcessor : ProjectOpenProcessorBase<DubProjectImportBuilder
         return ArrayUtil.contains(file.name, *SUPPORTED_FILES)
     }
 
-    override fun doOpenProject(
+    override suspend fun openProjectAsync(
         virtualFile: VirtualFile,
         projectToClose: Project?,
         forceOpenInNewFrame: Boolean
@@ -76,7 +76,7 @@ class DubProjectOpenProcessor : ProjectOpenProcessorBase<DubProjectImportBuilder
         if (project != null) {
             // Run on EDT for with the ability to take a write action lock
             ApplicationManager.getApplication().invokeLater {
-                var mm = ModuleManager.getInstance(project)
+                val mm = ModuleManager.getInstance(project)
                 mm.modules.forEach{
                     // I couldn't figure out where project was gaining the additional module(s)
                     // so we'll just dispose it and it'll be fine and things should work ok without it
@@ -100,7 +100,7 @@ class DubProjectOpenProcessor : ProjectOpenProcessorBase<DubProjectImportBuilder
     }
 
     // Need to override when extending ProjectOpenProcessorBase<DubProjectImportBuilder>
-    override fun doQuickImport(file: VirtualFile, context: WizardContext): Boolean {
+    override fun doQuickImport(file: VirtualFile, wizardContext: WizardContext): Boolean {
         val builder: DubProjectImportBuilder =
             ProjectImportBuilder.EXTENSIONS_POINT_NAME.findExtensionOrFail(
                 DubProjectImportBuilder::class.java
@@ -110,7 +110,7 @@ class DubProjectOpenProcessor : ProjectOpenProcessorBase<DubProjectImportBuilder
             builder.getParameters().dubBinary = DubBinaryPathProvider.getDubPath()
             //builder.setRootDirectory(context.getProjectFileDirectory());
             builder.setRootDirectory(rootDirectory.path)
-            context.projectName = rootDirectory.name
+            wizardContext.projectName = rootDirectory.name
             LOG.debug("Opening dub project")
             true
         } else {

--- a/errorreporting/build.gradle.kts
+++ b/errorreporting/build.gradle.kts
@@ -16,6 +16,6 @@ dependencies {
     implementation(project(":utils"))
     implementation(libs.sentry)
     intellijPlatform {
-        intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
+        intellijIdea(providers.gradleProperty("ideaVersion").get())
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,20 +4,21 @@
 
 # https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
 # 2024.3    (243.21565.193) bundled with Kotlin stdlib 2.0.21
-# 2025.1    (251.23774.435) bundled with Kotlin stdlin 2.1.10
-# 2025.1.3  (251.26927.53) bundled with Kotlin stdlin 2.1.10
-# 2025.2    (252.23892.269) bundled with Kotlin stdlin 2.1.20
+# 2025.1    (251.23774.435) bundled with Kotlin stdlib 2.1.10
+# 2025.1.3  (251.26927.53) bundled with Kotlin stdlib 2.1.10
+# 2025.2    (252.23892.269) bundled with Kotlin stdlib 2.1.20
+# 2025.3    (253.28294.334) bundled with Kotlin stdlib 2.2.20
 
-pluginVersion = 1.38.1
+pluginVersion = 1.39
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-ideaVersion = 2025.1
+ideaVersion = 2025.3
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 251
-pluginUntilBuild = 252.*
+pluginSinceBuild = 253
+pluginUntilBuild = 253.*
 
-psiViewerVersion = 2025.1
+psiViewerVersion = 253.7181
 
 # set via CI
 publishChannels=

--- a/sdlang/build.gradle.kts
+++ b/sdlang/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     testRuntimeOnly (libs.junit.engine)
 
     intellijPlatform {
-        intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
+        intellijIdea(providers.gradleProperty("ideaVersion").get())
         testFramework(TestFrameworkType.Platform)
     }
 }

--- a/src/main/kotlin/io/github/intellij/dlanguage/project/wizard/DlangNewProjectWizard.kt
+++ b/src/main/kotlin/io/github/intellij/dlanguage/project/wizard/DlangNewProjectWizard.kt
@@ -27,7 +27,7 @@ class DlangNewProjectWizard : LanguageGeneratorNewProjectWizard {
 
         override val self = this
 
-        override val label = "Build System:"
+        override val label = "Build System:" // todo: use DlangBundle message bundle
 
         override val buildSystemProperty by ::stepProperty
 

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     testRuntimeOnly (libs.junit.engine)
 
     intellijPlatform {
-        intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
+        intellijIdea(providers.gradleProperty("ideaVersion").get())
         bundledPlugins("com.intellij.platform.images")
         testFramework(TestFrameworkType.Platform)
     }

--- a/utils/src/main/resources/i18n.properties
+++ b/utils/src/main/resources/i18n.properties
@@ -1,6 +1,8 @@
+compilers.dlang.generic=D Compiler
 compilers.dmd.presentableName=DMD (Reference D Compiler)
 compilers.ldc.presentableName=LDC (LLVM-based D Compiler)
 compilers.gdc.presentableName=GDC (The GNU D Compiler)
+compilers.opend.presentableName=OpenD (Fork of DMD)
 
 dlang.filetype=D language file
 


### PR DESCRIPTION
2025.3 has breaking changes for the codebase. Unless there's anything that should be merged first for a last 1.38.x release then I suggest we just jump to making 2025.3 the new minimum requirement