### PR TITLE
[#678,#1187]: enable & disable DCD server via actions in UI

### DIFF
--- a/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
+++ b/dlang/plugin-impl/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,9 @@
     </extensionPoints>
 
     <extensions defaultExtensionNs="com.intellij">
+        <!-- todo: have resource bundles specific to key modules. Eg dub, sdlang, debugger, dcd, serve-d, etc -->
+        <languageBundle key="i18n" path="i18n"/>
+        <languageBundle key="dcd-i18n" path="dcd-i18n"/>
 
         <!-- Add your extensions here -->
         <codeInsight.parameterInfo language="D" implementationClass="io.github.intellij.dlanguage.codeinsight.ParameterInfo"/>
@@ -311,13 +314,20 @@
             <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt K"/>
             <synonym text="DFMT" />
         </action>
-        <action id="io.github.intellij.dlanguage.actions.RestartDCD"
-                class="io.github.intellij.dlanguage.actions.RestartDCD"
-                text="Restart DCD Server"
-                description="Restarts the DCD server"
-                icon="AllIcons.Actions.Restart">
-            <add-to-group group-id="ToolsMenu" anchor="last"/>
-        </action>
+
+        <!-- Group DCD related actions in the Tools Menu -->
+        <group id="dlang-dcd-tools-menu-group"
+               text="DCD (D completion server)"
+               popup="true">
+            <add-to-group group-id="ToolsMenu" anchor="last" />
+
+            <action id="io.github.intellij.dlanguage.actions.RestartDCD"
+                    class="io.github.intellij.dlanguage.actions.RestartDCD">
+            </action>
+            <action id="io.github.intellij.dlanguage.actions.StopDCDServer"
+                    class="io.github.intellij.dlanguage.actions.StopDCDServer">
+            </action>
+        </group>
     </actions>
 
 </idea-plugin>

--- a/dlang/plugin-impl/src/main/resources/dcd-i18n.properties
+++ b/dlang/plugin-impl/src/main/resources/dcd-i18n.properties
@@ -1,0 +1,11 @@
+# text resources here are specifically for DCD, and not for the plugin as a whole.
+
+dcd.action.restart.text=Restart DCD server
+dcd.action.restart.description=Restarts the DCD server
+dcd.action.stop.text=Stop DCD server
+dcd.action.stop.description=Stops DCD server
+
+# used in base DCD Action
+dcd.no-active-project=No active project.
+dcd.no-active-modules=No D modules were found in this project.
+dcd.no-module-component=Could not find module component for dcd-server.

--- a/src/main/java/io/github/intellij/dlanguage/actions/BaseDCDAction.java
+++ b/src/main/java/io/github/intellij/dlanguage/actions/BaseDCDAction.java
@@ -1,0 +1,116 @@
+package io.github.intellij.dlanguage.actions;
+
+import com.intellij.notification.NotificationGroupManager;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleTypeManager;
+import com.intellij.openapi.module.ModuleUtil;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.NlsContexts;
+import com.intellij.ui.popup.PopupFactoryImpl;
+import com.intellij.util.Consumer;
+import io.github.intellij.dlanguage.DLanguage;
+import io.github.intellij.dlanguage.codeinsight.dcd.DCDCompletionServer;
+import io.github.intellij.dlanguage.settings.ToolKey;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.ResourceBundle;
+
+/**
+ * All actions for controlling DCD Server will need to check that the server is configured and be aware of its current state.
+ * Use this base class to share common code.
+ */
+public abstract class BaseDCDAction extends AnAction implements DumbAware { // todo: consider implementing LightEditCompatible
+
+    private static final String NOTIFICATION_GROUP_ID = DCDCompletionServer.NOTIFICATION_GROUP_ID;
+
+    protected static final String DCD_I18N_BUNDLE_NAME = "dcd-i18n";
+
+    @NlsContexts.NotificationTitle
+    protected static final String NOTIFICATION_TITLE = "DCD server";
+
+    protected static final ResourceBundle i18n = ResourceBundle.getBundle(DCD_I18N_BUNDLE_NAME);
+
+    protected BaseDCDAction(@NotNull String text, @NotNull String description, @NotNull Icon icon) {
+        super(text, description, icon);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
+    @Nullable
+    protected DCDCompletionServer getDCDCompletionServer(@NotNull Module m) {
+        return m.getService(DCDCompletionServer.class);
+    }
+
+    @Override
+    public void actionPerformed(@NotNull final AnActionEvent e) {
+        final Project project = e.getProject();
+        if (project == null) {
+            displayNotification(e, i18n.getString("dcd.no-active-project"), NotificationType.ERROR);
+            return;
+        }
+
+        final Collection<Module> modules = ModuleUtil.getModulesOfType(project, ModuleTypeManager.getInstance().findByID(DLanguage.MODULE_TYPE_ID));
+        final int size = modules.size();
+        if (size == 0) displayNotification(e, i18n.getString("dcd.no-active-modules"), NotificationType.ERROR);
+        else if (size == 1) performActionWithModule(e, modules.iterator().next());
+        else this.showModuleChoicePopup(e, project, modules, module -> performActionWithModule(e, module));
+    }
+
+    private void performActionWithModule(@NotNull final AnActionEvent e, @NotNull final Module module) {
+        final DCDCompletionServer dcdServer = getDCDCompletionServer(module);
+        if (dcdServer != null) {
+            performDcdServerAction(dcdServer);
+        } else {
+            displayNotification(
+                e,
+                i18n.getString("dcd.no-module-component"),
+                NotificationType.ERROR
+            );
+        }
+    }
+
+    /**
+     * Perform an action on the dcd server. The server is guaranteed to be non-null and running when this method is called.
+     * @param dcdServer invoke the required action on this server instance.
+     */
+    abstract void performDcdServerAction(@NotNull final DCDCompletionServer dcdServer);
+
+    protected boolean dcdServerPathAvailable() {
+        final String dcdServerPath = ToolKey.DCD_SERVER_KEY.getPath();
+        return dcdServerPath != null && !dcdServerPath.isEmpty() && Paths.get(dcdServerPath).toFile().canExecute();
+    }
+
+    protected void showModuleChoicePopup(@NotNull final AnActionEvent e, final Project project, final Collection<Module> modules, final Consumer<Module> moduleChosenCallback) {
+        PopupFactoryImpl.getInstance()
+            .createPopupChooserBuilder(new ArrayList<>(modules))
+            .setTitle(e.getPresentation().getText()) //.setAdText("Module selection")
+            .setItemChosenCallback(moduleChosenCallback)
+            .createPopup()
+            .showCenteredInCurrentWindow(project);
+    }
+
+    protected void displayNotification(
+        @NotNull final AnActionEvent e,
+        @NlsContexts.NotificationContent final String message,
+        @NotNull final NotificationType type
+    ) {
+        // Could potentially use e.getPresentation().getText() for notification title
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup(NOTIFICATION_GROUP_ID)
+            .createNotification(NOTIFICATION_TITLE, message, type)
+            .notify(getEventProject(e));
+    }
+}

--- a/src/main/java/io/github/intellij/dlanguage/actions/RestartDCD.java
+++ b/src/main/java/io/github/intellij/dlanguage/actions/RestartDCD.java
@@ -1,92 +1,44 @@
 package io.github.intellij.dlanguage.actions;
 
-import com.intellij.notification.NotificationGroupManager;
-import com.intellij.notification.NotificationType;
-import com.intellij.openapi.actionSystem.ActionUpdateThread;
-import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleTypeManager;
 import com.intellij.openapi.module.ModuleUtil;
-import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
-import com.intellij.ui.popup.PopupFactoryImpl;
 import io.github.intellij.dlanguage.DLanguage;
 import io.github.intellij.dlanguage.codeinsight.dcd.DCDCompletionServer;
-import io.github.intellij.dlanguage.settings.ToolKey;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
-public class RestartDCD extends AnAction implements DumbAware { // todo: consider implementing LightEditCompatible
-
-    private static final Logger LOG = Logger.getInstance(RestartDCD.class);
+public class RestartDCD extends BaseDCDAction {
 
     // DO NOT CHANGE THE ID WITHOUT ALSO MAKING SURE THAT THE SAME STRING IS USED IN plugin.xml
     public static final String ID = "io.github.intellij.dlanguage.actions.RestartDCD";
 
-    public static final String MENU_PATH = "Tools > Restart DCD Server";
+    public RestartDCD() {
+        super(
+            i18n.getString("dcd.action.restart.text"),
+            i18n.getString("dcd.action.restart.description"),
+            AllIcons.Actions.Restart
+        );
+    }
 
     // called frequently so needs to be fast! Can be x2 times per second
     @Override
     public void update(@NotNull final AnActionEvent e) {
-        e.getPresentation().setEnabled(enabled(e));
+        e.getPresentation().setEnabled(restartEnabled(e));
     }
 
-    private static boolean enabled(@NotNull final AnActionEvent e) {
-        final Project project = getEventProject(e);
+    private boolean restartEnabled(@NotNull final AnActionEvent e) {
+        @Nullable final Project project = getEventProject(e);
         if (project == null) return false;
-        final String dcdServerPath = ToolKey.DCD_SERVER_KEY.getPath();
-        return dcdServerPath != null && !dcdServerPath.isEmpty() &&
-            ModuleUtil.getModulesOfType(project, ModuleTypeManager.getInstance().findByID(DLanguage.MODULE_TYPE_ID))
-                .size() > 0;
+        return super.dcdServerPathAvailable() &&
+            !ModuleUtil.getModulesOfType(project, ModuleTypeManager.getInstance().findByID(DLanguage.MODULE_TYPE_ID)).isEmpty();
     }
 
     @Override
-    public void actionPerformed(@NotNull final AnActionEvent e) {
-        final String prefix = "Unable to restart dcd-server - ";
-        final Project project = e.getProject();
-        if (project == null) { displayError(e, prefix + "No active project."); return; }
-
-        final Collection<Module> modules = ModuleUtil.getModulesOfType(project, ModuleTypeManager.getInstance().findByID(DLanguage.MODULE_TYPE_ID));
-        final int size = modules.size();
-        if (size == 0) displayError(e, prefix + "No DLanguage modules are used in this project.");
-        else if (size == 1) restartDcdServer(e, modules.iterator().next());
-        else showModuleChoicePopup(e, project, modules);
+    void performDcdServerAction(@NotNull DCDCompletionServer dcdServer) {
+        dcdServer.restart();
     }
 
-    @Override
-    public @NotNull ActionUpdateThread getActionUpdateThread() {
-        return ActionUpdateThread.BGT;
-    }
-
-    private static void showModuleChoicePopup(@NotNull final AnActionEvent e, final Project project, final Collection<Module> modules) {
-        PopupFactoryImpl.getInstance()
-            .createPopupChooserBuilder(new ArrayList<>(modules))
-            .setTitle("Restart dcd-server for module")
-            .setItemChosenCallback(module -> restartDcdServer(e, module))
-            .createPopup()
-            .showCenteredInCurrentWindow(project);
-    }
-
-    private static void restartDcdServer(@NotNull final AnActionEvent e, @NotNull final Module module) {
-        final DCDCompletionServer dcdServer = module.getService(DCDCompletionServer.class);
-        if (dcdServer == null) displayError(e, "Could not find module component for dcd-server.");
-        else dcdServer.restart();
-    }
-
-    private static void displayError(@NotNull final AnActionEvent e, @NotNull final String message) {
-        final String groupId = e.getPresentation().getText();
-        NotificationGroupManager.getInstance()
-            .getNotificationGroup(groupId)
-            .createNotification(
-                "Restart dcd-server",
-                message,
-                NotificationType.ERROR
-            )
-            .notify(getEventProject(e));
-        LOG.warn(message);
-    }
 }

--- a/src/main/java/io/github/intellij/dlanguage/actions/StopDCDServer.java
+++ b/src/main/java/io/github/intellij/dlanguage/actions/StopDCDServer.java
@@ -1,0 +1,51 @@
+package io.github.intellij.dlanguage.actions;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleTypeManager;
+import com.intellij.openapi.module.ModuleUtil;
+import com.intellij.openapi.project.Project;
+import io.github.intellij.dlanguage.DLanguage;
+import io.github.intellij.dlanguage.codeinsight.dcd.DCDCompletionServer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+public class StopDCDServer extends BaseDCDAction {
+
+    // DO NOT CHANGE THE ID WITHOUT ALSO MAKING SURE THAT THE SAME STRING IS USED IN plugin.xml
+    public static final String ID = "io.github.intellij.dlanguage.actions.StopDCDServer";
+
+    public StopDCDServer() {
+        super(
+            i18n.getString("dcd.action.stop.text"),
+            i18n.getString("dcd.action.stop.description"),
+            AllIcons.Actions.Suspend
+        );
+    }
+
+    @Override
+    public void update(@NotNull final AnActionEvent e) {
+        e.getPresentation().setEnabled(dcdServerRunning(e));
+    }
+
+    @Override
+    void performDcdServerAction(@NotNull DCDCompletionServer dcdServer) {
+        dcdServer.kill();
+    }
+
+    private boolean dcdServerRunning(@NotNull final AnActionEvent e) {
+        @Nullable final Project project = getEventProject(e);
+        if (project == null) return false;
+
+        final Collection<Module> modules = ModuleUtil.getModulesOfType(project, ModuleTypeManager.getInstance().findByID(DLanguage.MODULE_TYPE_ID));
+        if (modules.isEmpty()) return false;
+
+        @Nullable final DCDCompletionServer dcd = super.getDCDCompletionServer(modules.iterator().next());
+        if (dcd == null) return false;
+
+        return super.dcdServerPathAvailable() && dcd.isRunning();
+    }
+}

--- a/src/main/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionServer.java
+++ b/src/main/java/io/github/intellij/dlanguage/codeinsight/dcd/DCDCompletionServer.java
@@ -49,6 +49,11 @@ public final class DCDCompletionServer implements ToolChangeListener, Disposable
 
     private static final Logger LOG = Logger.getInstance(DCDCompletionServer.class);
 
+    /**
+     * The notification group id is defined in plugin.xml and must match the string used there.
+     */
+    public static final String NOTIFICATION_GROUP_ID = "DCDNotification";
+
     @NotNull
     public Module module;
 
@@ -79,8 +84,12 @@ public final class DCDCompletionServer implements ToolChangeListener, Disposable
         return StringUtil.isNotEmpty(path);
     }
 
+    /**
+     * Checks if the process is alive. Fos use in UI components that can indicate if the server is running
+     * @return true if there is a process running.
+     */
     public boolean isRunning() {
-        return StringUtil.isNotEmpty(path) && processHandler != null && processHandler.getProcess().isAlive();
+        return processHandler != null && processHandler.getProcess().isAlive();
     }
 
     public synchronized void exec() {
@@ -122,9 +131,9 @@ public final class DCDCompletionServer implements ToolChangeListener, Disposable
             LOG.info("DCD process started");
         } catch (final ExecutionException e) {
             NotificationGroupManager.getInstance()
-                .getNotificationGroup("DCDNotification")
+                .getNotificationGroup(NOTIFICATION_GROUP_ID)
                 .createNotification(
-                    "DCD Error",
+                    "DCD error",
                     "Unable to start a dcd server. Make sure that you have specified the path to the dcd-server and dcd-client executables correctly. You can specify executable paths under File > Settings > Languages & Frameworks > D Tools",
                     NotificationType.ERROR
                 )
@@ -213,8 +222,9 @@ public final class DCDCompletionServer implements ToolChangeListener, Disposable
 
     /**
      * Kills the existing process and closes input and output if they exist.
+     * It's public so that the RestartDCDAction can use it to manually kill the server.
      */
-    private synchronized void kill() {
+    public synchronized void kill() {
         if (processHandler != null) {
             LOG.info("Shutting down DCD Server...");
             processHandler.destroyProcess();
@@ -225,6 +235,7 @@ public final class DCDCompletionServer implements ToolChangeListener, Disposable
 
     /**
      * Restarts the dcd-server.
+     * It's public so that the RestartDCDAction can use it to manually restart the server.
      */
     public synchronized void restart() {
         kill();


### PR DESCRIPTION
Allow users to manually start & stop DCD server via the UI. Actions available from tool menu and status bar widget:

https://github.com/user-attachments/assets/86c5e7b3-6523-4fe0-851b-f8f408f0ace5

