### PR TITLE
fix(#1170): Make the "# line ..." not erroring the parser

### DIFF
--- a/dlang/psi-impl/src/main/jflex/io/github/intellij/dlanguage/lexer/DLanguageLexer.flex
+++ b/dlang/psi-impl/src/main/jflex/io/github/intellij/dlanguage/lexer/DLanguageLexer.flex
@@ -37,7 +37,12 @@ import io.github.intellij.dlanguage.psi.DlangTypes;
 
 WHITE_SPACE_CHAR = [\ \t\f]
 NEW_LINE = [\n\r]
-WHITE_SPACE = ({WHITE_SPACE_CHAR}|{NEW_LINE})+
+
+// This sequence is special to the compiler, and can be inserted anywhere. Treat it as whitespace for now, to not have parsing error
+// If we want to improve it support, a complete implementation is necessary
+SPECIAL_TOKEN_SEQUENCE = "#"{WHITE_SPACE_CHAR}*line.*{NEW_LINE}
+
+WHITE_SPACE = ({WHITE_SPACE_CHAR}|{NEW_LINE}|{SPECIAL_TOKEN_SEQUENCE})+
 
 ID = (_|\p{xid_start}) (\p{xid_continue})*
 

--- a/src/test/kotlin/io/github/intellij/dlanguage/lexer/DlangLexerTest.kt
+++ b/src/test/kotlin/io/github/intellij/dlanguage/lexer/DlangLexerTest.kt
@@ -201,6 +201,8 @@ BAD_CHARACTER ('q"/test"d;')
     fun testtokens_xor()                  = doTest()
     fun testtokens_xor_assign()           = doTest()
 
+    fun testspecial_token_sequence()      = doTest()
+
     //issue 77
     fun testissue77() = doTest()
 

--- a/src/test/resources/gold/lexer/expected/special_token_sequence.txt
+++ b/src/test/resources/gold/lexer/expected/special_token_sequence.txt
@@ -1,0 +1,5 @@
+WHITE_SPACE ('#line 10\n\n')
+DlangTokenType.int ('int')
+WHITE_SPACE (' # line 26 "package lol"\n')
+DlangTokenType.ID ('x')
+DlangTokenType.; (';')

--- a/src/test/resources/gold/lexer/special_token_sequence.d
+++ b/src/test/resources/gold/lexer/special_token_sequence.d
@@ -1,0 +1,4 @@
+#line 10
+
+int # line 26 "package lol"
+x;


### PR DESCRIPTION
This is a very very simple implementation, but at least parser is not lost. The implementation consider it as a whitespace, so no possibility to customize it for colors (it will always be white). A future proper implementation can be made in the future.

Closes #1170 